### PR TITLE
Simplify gamepad button/axis labelling

### DIFF
--- a/scripts/__input_binding_get_label/__input_binding_get_label.gml
+++ b/scripts/__input_binding_get_label/__input_binding_get_label.gml
@@ -27,49 +27,36 @@ function __input_binding_get_label(_type, _value, _axis_negative)
             return "mouse wheel down";
         break;
         
+        case "gamepad axis":
         case "gamepad button":
             switch(_value)
             {
-                case gp_face1:      return "gamepad button south";              break; // xbox A
-                case gp_face2:      return "gamepad button east";               break; // xbox B
-                case gp_face3:      return "gamepad button west";               break; // xbox X
-                case gp_face4:      return "gamepad button north";              break; // xbox Y
-                case gp_shoulderl:  return "gamepad button shoulder l";         break;
-                case gp_shoulderr:  return "gamepad button shoulder r";         break;
-                case gp_shoulderlb: return "gamepad button trigger l";          break;
-                case gp_shoulderrb: return "gamepad button trigger r";          break;
-                case gp_select:     return "gamepad button select";             break;
-                case gp_start:      return "gamepad button start";              break;
-                case gp_stickl:     return "gamepad button thumbstick l click"; break;
-                case gp_stickr:     return "gamepad button thumbstick r click"; break;
-                case gp_padu:       return "gamepad button dpad up";            break;
-                case gp_padd:       return "gamepad button dpad down";          break;
-                case gp_padl:       return "gamepad button dpad left";          break;
-                case gp_padr:       return "gamepad button dpad right"          break;
-                case gp_guide:      return "gamepad button guide";              break;
-                case gp_misc1:      return "gamepad button misc 1";             break;
+                case gp_face1:      return "gamepad button south";           break; // xbox A
+                case gp_face2:      return "gamepad button east";            break; // xbox B
+                case gp_face3:      return "gamepad button west";            break; // xbox X
+                case gp_face4:      return "gamepad button north";           break; // xbox Y
+                case gp_select:     return "gamepad button select";          break;
+                case gp_start:      return "gamepad button start";           break;
+                case gp_guide:      return "gamepad button guide";           break;
                 
-                case gp_axislh: return _axis_negative? "gamepad button thumbstick l left" : "gamepad button thumbstick l right"; break;
-                case gp_axislv: return _axis_negative? "gamepad button thumbstick l up"   : "gamepad button thumbstick l down";  break;
-                case gp_axisrh: return _axis_negative? "gamepad button thumbstick r left" : "gamepad button thumbstick r right"; break;
-                case gp_axisrv: return _axis_negative? "gamepad button thumbstick r up"   : "gamepad button thumbstick r down";  break;
+                case gp_misc1:      return _type + " misc 1";                break;
+                case gp_shoulderl:  return _type + " shoulder l";            break;
+                case gp_shoulderr:  return _type + " shoulder r";            break;
+                case gp_shoulderlb: return _type + " trigger l";             break;
+                case gp_shoulderrb: return _type + " trigger r";             break;
+                case gp_stickl:     return _type + " thumbstick l click";    break;
+                case gp_stickr:     return _type + " thumbstick r click";    break;
+                case gp_padu:       return _type + " dpad up";               break;
+                case gp_padd:       return _type + " dpad down";             break;
+                case gp_padl:       return _type + " dpad left";             break;
+                case gp_padr:       return _type + " dpad right"             break;
                 
-                default: return "gamepad button unknown"; break;
-            }
-        break;
-        
-        case "gamepad axis":
-            switch(_value)
-            {
-                case gp_shoulderlb: return "gamepad axis trigger l"; break;
-                case gp_shoulderrb: return "gamepad axis trigger r"; break;
+                case gp_axislh: return _axis_negative? _type + " thumbstick l left" : _type + " thumbstick l right"; break;
+                case gp_axislv: return _axis_negative? _type + " thumbstick l up"   : _type + " thumbstick l down";  break;
+                case gp_axisrh: return _axis_negative? _type + " thumbstick r left" : _type + " thumbstick r right"; break;
+                case gp_axisrv: return _axis_negative? _type + " thumbstick r up"   : _type + " thumbstick r down";  break;
                 
-                case gp_axislh: return _axis_negative? "gamepad axis thumbstick l left" : "gamepad axis thumbstick l right"; break;
-                case gp_axislv: return _axis_negative? "gamepad axis thumbstick l up"   : "gamepad axis thumbstick l down";  break;
-                case gp_axisrh: return _axis_negative? "gamepad axis thumbstick r left" : "gamepad axis thumbstick r right"; break;
-                case gp_axisrv: return _axis_negative? "gamepad axis thumbstick r up"   : "gamepad axis thumbstick r down";  break;
-                
-                default: return "gamepad axis unknown"; break;
+                default: return _type + " unknown"; break;
             }
         break;
         

--- a/scripts/__input_binding_get_label/__input_binding_get_label.gml
+++ b/scripts/__input_binding_get_label/__input_binding_get_label.gml
@@ -31,25 +31,26 @@ function __input_binding_get_label(_type, _value, _axis_negative)
         case "gamepad button":
             switch(_value)
             {
-                case gp_face1:      return "gamepad button south";           break; // xbox A
-                case gp_face2:      return "gamepad button east";            break; // xbox B
-                case gp_face3:      return "gamepad button west";            break; // xbox X
-                case gp_face4:      return "gamepad button north";           break; // xbox Y
-                case gp_select:     return "gamepad button select";          break;
-                case gp_start:      return "gamepad button start";           break;
-                case gp_guide:      return "gamepad button guide";           break;
+                case gp_face1:      return "gamepad button south";          break; // xbox A
+                case gp_face2:      return "gamepad button east";           break; // xbox B
+                case gp_face3:      return "gamepad button west";           break; // xbox X
+                case gp_face4:      return "gamepad button north";          break; // xbox Y
+                case gp_select:     return "gamepad button select";         break;
+                case gp_start:      return "gamepad button start";          break;
+                case gp_guide:      return "gamepad button guide";          break;
+
+                case gp_padu:       return "gamepad dpad up";               break;
+                case gp_padd:       return "gamepad dpad down";             break;
+                case gp_padl:       return "gamepad dpad left";             break;
+                case gp_padr:       return "gamepad dpad right"             break;
+                case gp_stickl:     return "gamepad thumbstick l click";    break;
+                case gp_stickr:     return "gamepad thumbstick r click";    break;
                 
                 case gp_misc1:      return _type + " misc 1";                break;
                 case gp_shoulderl:  return _type + " shoulder l";            break;
                 case gp_shoulderr:  return _type + " shoulder r";            break;
                 case gp_shoulderlb: return _type + " trigger l";             break;
                 case gp_shoulderrb: return _type + " trigger r";             break;
-                case gp_stickl:     return _type + " thumbstick l click";    break;
-                case gp_stickr:     return _type + " thumbstick r click";    break;
-                case gp_padu:       return _type + " dpad up";               break;
-                case gp_padd:       return _type + " dpad down";             break;
-                case gp_padl:       return _type + " dpad left";             break;
-                case gp_padr:       return _type + " dpad right"             break;
                 
                 case gp_axislh: return _axis_negative? _type + " thumbstick l left" : _type + " thumbstick l right"; break;
                 case gp_axislv: return _axis_negative? _type + " thumbstick l up"   : _type + " thumbstick l down";  break;


### PR DESCRIPTION
buttons and axes can both map anything, no meaningful reason to separate afaict? i've left "obviously buttons" labeled just button, since to have them labeled otherwise would be needlessly confusing. cases this fixes include axis-on-dpad, axis-on-shoulder, etc.