### PR TITLE
Removes hint for text input source on UWP

### DIFF
--- a/scripts/input_platform_text_source/input_platform_text_source.gml
+++ b/scripts/input_platform_text_source/input_platform_text_source.gml
@@ -1,6 +1,6 @@
 function input_platform_text_source()
 {
-    if (__INPUT_ON_WEB || __INPUT_ON_CONSOLE || (os_type == os_uwp))
+    if (__INPUT_ON_WEB || __INPUT_ON_CONSOLE)
     {
         return "async";
     }


### PR DESCRIPTION
> async doesn't seem to work on XB1 UWP? Return key doesn't dismiss the keyboard
> @jujuadams