### PR TITLE
Gamepad platform fixes

### DIFF
--- a/scripts/__input_gamepad_set_description/__input_gamepad_set_description.gml
+++ b/scripts/__input_gamepad_set_description/__input_gamepad_set_description.gml
@@ -2,7 +2,7 @@
 
 function __input_gamepad_set_description()
 {
-    if (xinput)
+    if (xinput || os_type == os_xboxone || os_type == os_xboxseriesxs)
     {
         description = "XInput";
     }

--- a/scripts/__input_gamepad_set_type/__input_gamepad_set_type.gml
+++ b/scripts/__input_gamepad_set_type/__input_gamepad_set_type.gml
@@ -169,6 +169,10 @@ function __input_gamepad_set_type()
                 {
                     raw_type = "CommunityXBox360";
                 }
+                else if (__INPUT_ON_MOBILE && __INPUT_ON_APPLE)
+                {
+                    raw_type = "AppleController";
+                }
                 else
                 {
                     raw_type = "Unknown";

--- a/scripts/__input_gamepad_set_vid_pid/__input_gamepad_set_vid_pid.gml
+++ b/scripts/__input_gamepad_set_vid_pid/__input_gamepad_set_vid_pid.gml
@@ -4,8 +4,9 @@ function __input_gamepad_set_vid_pid()
 {    
     if (__INPUT_ON_WEB)
     {
-        //We have no way of determining XInput status reliably on web (not that it would be especially useful)
-        xinput = undefined;
+        vendor  = "";
+        product = "";
+        xinput  = undefined;
         
         //Try to read from Chrome's VID/PID syntax
         // e.g. Description Vendor: xxxx Product: yyyy

--- a/scripts/input_platform_text_source/input_platform_text_source.gml
+++ b/scripts/input_platform_text_source/input_platform_text_source.gml
@@ -1,6 +1,6 @@
 function input_platform_text_source()
 {
-    if (__INPUT_ON_WEB || __INPUT_ON_CONSOLE)
+    if (__INPUT_ON_WEB || __INPUT_ON_CONSOLE || (os_type == os_uwp))
     {
         return "async";
     }


### PR DESCRIPTION
1. Addresses HTML5 platform crash bug for XInput gamepads, and any case where normative VID and PID are not found, fixing user-raised crash bug on Discord

2. Sets description consistent with UWP and Windows on Xbox platform

3. Sets type fallback on iOS and tvOS