### PR TITLE
Prevent offset to out-of-bounds axes

### DIFF
--- a/scripts/__input_gamepad_set_mapping/__input_gamepad_set_mapping.gml
+++ b/scripts/__input_gamepad_set_mapping/__input_gamepad_set_mapping.gml
@@ -423,7 +423,8 @@ function __input_gamepad_set_mapping()
                             if (__INPUT_DEBUG) __input_trace("  (Limiting axis range)");
                             _mapping.limit_range = true;
                         }
-                        else if ((os_type != os_linux) && !_is_directional)
+                        else if ((os_type != os_linux) && !_is_directional
+                             && (gamepad_axis_count(index) >= _input_slot))
                         {
                             //Nondirectional input uses full axis range (excepting Linux remappings and XInput)
                             if (__INPUT_DEBUG) __input_trace("  (Extending axis range)");


### PR DESCRIPTION
Prevents bad maps or device variants from setting missing axis to nonzero