### PR TITLE
Consistency for label and color checkers, removes fallback

### DIFF
--- a/scripts/__input_config/__input_config.gml
+++ b/scripts/__input_config/__input_config.gml
@@ -21,8 +21,7 @@
 #macro INPUT_SDL2_ALLOW_GUIDE     false  //Whether to allow use of SDL2's "guide" binding, accessed using the gp_guide macro. This generally only works with DInput controllers
 #macro INPUT_SDL2_ALLOW_MISC1     false  //Whether to allow use of SDL2's "misc1" binding, accessed using the gp_misc1 macro. What this maps to varies from controller to controller
 
-#macro INPUT_DEFAULT_BUTTON_LABELS_AND_COLORS  "XBoxOneController"
-#macro INPUT_LOAD_BUTTON_LABELS_AND_COLORS     true
+#macro INPUT_LOAD_BUTTON_LABELS_AND_COLORS  true //Whether to load external gamepad button label and color databases
 
 #macro INPUT_MAX_TOUCHPOINTS        11     //Maximum number of touch screen points to query. Touch devices only (excludes PlayStation)
 #macro INPUT_TOUCH_EDGE_DEADZONE    35     //Margin in pixels around the screen edge where gaining or losing a touch point will not register "pressed" or "released". Prevents false positives when dragging on to or off of the edge of a touchscreen.

--- a/scripts/__input_load_button_color_csv/__input_load_button_color_csv.gml
+++ b/scripts/__input_load_button_color_csv/__input_load_button_color_csv.gml
@@ -45,9 +45,6 @@ function __input_load_button_color_csv(_filename)
         ++_y;
     }
     
-    //Set the "Unknown" controller type to the same struct as our default controller type
-    global.__input_button_color_dictionary[$ "Unknown"] = global.__input_button_color_dictionary[$ INPUT_DEFAULT_BUTTON_LABELS_AND_COLORS];
-    
     __input_trace(_count, " button color definitions found");
     __input_trace("Loaded in ", (get_timer() - _t)/1000, "ms");
     

--- a/scripts/__input_load_button_label_csv/__input_load_button_label_csv.gml
+++ b/scripts/__input_load_button_label_csv/__input_load_button_label_csv.gml
@@ -60,9 +60,6 @@ function __input_load_button_label_csv(_filename)
         }
     }
     
-    //Set the "Unknown" controller type to the same struct as our default controller type
-    global.__input_button_label_dictionary[$ "Unknown"] = global.__input_button_label_dictionary[$ INPUT_DEFAULT_BUTTON_LABELS_AND_COLORS];
-    
     __input_trace(_count, " button label definitions found");
     __input_trace("Loaded in ", (get_timer() - _t)/1000, "ms");
     

--- a/scripts/__input_load_button_label_csv/__input_load_button_label_csv.gml
+++ b/scripts/__input_load_button_label_csv/__input_load_button_label_csv.gml
@@ -45,9 +45,6 @@ function __input_load_button_label_csv(_filename)
         ++_y;
     }
     
-    //Set the "Unknown" controller type to the same struct as our default controller type
-    global.__input_button_label_dictionary[$ "Unknown"] = global.__input_button_label_dictionary[$ INPUT_DEFAULT_BUTTON_LABELS_AND_COLORS];
-    
     __input_trace(_count, " button label definitions found");
     __input_trace("Loaded in ", (get_timer() - _t)/1000, "ms");
     

--- a/scripts/input_gamepad_get_button_color/input_gamepad_get_button_color.gml
+++ b/scripts/input_gamepad_get_button_color/input_gamepad_get_button_color.gml
@@ -3,7 +3,7 @@
 
 function input_gamepad_get_button_color(_index, _gm)
 {
-    if ((_index < 0) || (_index >= array_length(global.__input_gamepads))) return undefined;
+    if ((_index < 0) || (_index >= array_length(global.__input_gamepads))) return "unknown";
     
     var _gamepad = global.__input_gamepads[_index];
     if (!is_struct(_gamepad)) return "unknown";

--- a/scripts/input_gamepad_get_button_color/input_gamepad_get_button_color.gml
+++ b/scripts/input_gamepad_get_button_color/input_gamepad_get_button_color.gml
@@ -6,6 +6,7 @@ function input_gamepad_get_button_color(_index, _gm)
     if ((_index < 0) || (_index >= array_length(global.__input_gamepads))) return undefined;
     
     var _gamepad = global.__input_gamepads[_index];
-    if (!is_struct(_gamepad)) return undefined;
-    return _gamepad.get_button_color(_gm);
+    if (!is_struct(_gamepad)) return "unknown";
+    var _color = _gamepad.get_button_color(_gm);
+    return ((_color == undefined) ? "unknown" : _color);
 }

--- a/scripts/input_gamepad_get_button_label/input_gamepad_get_button_label.gml
+++ b/scripts/input_gamepad_get_button_label/input_gamepad_get_button_label.gml
@@ -4,6 +4,7 @@
 function input_gamepad_get_button_label(_index, _gm)
 {
     if ((_index < 0) || (_index >= array_length(global.__input_gamepads))) return "unknown";
+    
     var _gamepad = global.__input_gamepads[_index];
     if (!is_struct(_gamepad)) return "unknown";
     var _label = _gamepad.get_button_label(_gm);

--- a/scripts/input_gamepad_get_button_label/input_gamepad_get_button_label.gml
+++ b/scripts/input_gamepad_get_button_label/input_gamepad_get_button_label.gml
@@ -3,9 +3,8 @@
 
 function input_gamepad_get_button_label(_index, _gm)
 {
-    if ((_index < 0) || (_index >= array_length(global.__input_gamepads))) return undefined;
-    
+    if ((_index < 0) || (_index >= array_length(global.__input_gamepads))) return "unknown";
     var _gamepad = global.__input_gamepads[_index];
-    if (!is_struct(_gamepad)) return undefined;
-    return _gamepad.get_button_label(_gm);
-}
+    if (!is_struct(_gamepad)) return "unknown";
+    var _label = _gamepad.get_button_label(_gm);
+    return ((_label == undefined) ? "unknown" : _label);


### PR DESCRIPTION
We’ve already got gamepad type safety where necessary (console, Xinput, Apple mobile). [Unknown means unknown](https://github.com/JujuAdams/Input/pull/233#:~:text=Prevent%20name%2Dbased%20typing%20of%20generic%20adapters) ! Checkers restyled after `get_dpad_style` for lower friction.