### PR TITLE
Custom Gamepad Identifier

### DIFF
--- a/input.yyp
+++ b/input.yyp
@@ -65,6 +65,7 @@
     {"id":{"name":"input_mouse_y","path":"scripts/input_mouse_y/input_mouse_y.yy",},"order":4,},
     {"id":{"name":"input_default_key","path":"scripts/input_default_key/input_default_key.yy",},"order":3,},
     {"id":{"name":"input_default_mouse_button","path":"scripts/input_default_mouse_button/input_default_mouse_button.yy",},"order":4,},
+    {"id":{"name":"input_gamepad_get_identifier","path":"scripts/input_gamepad_get_identifier/input_gamepad_get_identifier.yy",},"order":13,},
     {"id":{"name":"input_default_mouse_wheel_down","path":"scripts/input_default_mouse_wheel_down/input_default_mouse_wheel_down.yy",},"order":5,},
     {"id":{"name":"input_default_mouse_wheel_up","path":"scripts/input_default_mouse_wheel_up/input_default_mouse_wheel_up.yy",},"order":6,},
     {"id":{"name":"input_direction","path":"scripts/input_direction/input_direction.yy",},"order":0,},

--- a/scripts/__input_class_gamepad/__input_class_gamepad.gml
+++ b/scripts/__input_class_gamepad/__input_class_gamepad.gml
@@ -11,6 +11,11 @@ function __input_class_gamepad(_index) constructor
     blacklisted       = false;
     sdl2_definition   = undefined;
     
+	
+	static custom_identifier_source = 0;
+	custom_identifier = custom_identifier_source++;
+	
+	
     vendor  = undefined;
     product = undefined;
     

--- a/scripts/input_gamepad_get_identifier/input_gamepad_get_identifier.gml
+++ b/scripts/input_gamepad_get_identifier/input_gamepad_get_identifier.gml
@@ -1,0 +1,10 @@
+/// @param gamepadIndex
+function input_gamepad_get_identifier(_index){
+
+	if ((_index < 0) || (_index >= array_length(global.__input_gamepads))) return "Unknown";
+    
+    var _gamepad = global.__input_gamepads[_index];
+    if (!is_struct(_gamepad)) return "Unknown";
+    return _gamepad.custom_identifier;
+
+}

--- a/scripts/input_gamepad_get_identifier/input_gamepad_get_identifier.yy
+++ b/scripts/input_gamepad_get_identifier/input_gamepad_get_identifier.yy
@@ -1,0 +1,12 @@
+{
+  "isDnD": false,
+  "isCompatibility": false,
+  "parent": {
+    "name": "Gamepads (Direct)",
+    "path": "folders/Input/Gamepads (Direct).yy",
+  },
+  "resourceVersion": "1.0",
+  "name": "input_gamepad_get_identifier",
+  "tags": [],
+  "resourceType": "GMScript",
+}


### PR DESCRIPTION
Adds custom_identifier value to __input_class_gamepad() struct.  

Allows developers to keep track of gamepads when they are reassigned to different player numbers during source_assigment_tick().

Adds input_gamepad_get_identifier(_index) to return the custom_identifier value assigned to that player's index.