### PR TITLE
Prevent gamepad source from thrashing during hotswap

### DIFF
--- a/scripts/input_player_gamepad_set/input_player_gamepad_set.gml
+++ b/scripts/input_player_gamepad_set/input_player_gamepad_set.gml
@@ -17,6 +17,12 @@ function input_player_gamepad_set(_gamepad, _player_index = 0)
         return undefined;
     }
     
+    if (!input_gamepad_is_connected(_gamepad))
+    {
+        __input_trace("Failed to set player gamepad: device not connected (Index ", _gamepad , ":\"" , gamepad_get_description(_gamepad) ,"\")");
+        return undefined;
+    }
+    
     var _player = global.__input_players[_player_index];
     if (_player.gamepad != _gamepad)
     {

--- a/scripts/input_player_gamepad_set/input_player_gamepad_set.gml
+++ b/scripts/input_player_gamepad_set/input_player_gamepad_set.gml
@@ -17,12 +17,6 @@ function input_player_gamepad_set(_gamepad, _player_index = 0)
         return undefined;
     }
     
-    if (!input_gamepad_is_connected(_gamepad))
-    {
-        __input_trace("Failed to set player gamepad: device not connected (Index ", _gamepad , ":\"" , gamepad_get_description(_gamepad) ,"\")");
-        return undefined;
-    }
-    
     var _player = global.__input_players[_player_index];
     if (_player.gamepad != _gamepad)
     {

--- a/scripts/input_player_gamepad_set/input_player_gamepad_set.gml
+++ b/scripts/input_player_gamepad_set/input_player_gamepad_set.gml
@@ -17,5 +17,11 @@ function input_player_gamepad_set(_gamepad, _player_index = 0)
         return undefined;
     }
     
-    global.__input_players[_player_index].gamepad = _gamepad;
+    var _player = global.__input_players[_player_index];
+    if (_player.gamepad != _gamepad)
+    {
+        _player.last_input_time = current_time;
+    }
+    
+    _player.gamepad = _gamepad;
 }

--- a/scripts/input_player_source_set/input_player_source_set.gml
+++ b/scripts/input_player_source_set/input_player_source_set.gml
@@ -17,5 +17,11 @@ function input_player_source_set(_source, _player_index = 0)
         return undefined;
     }
     
-    global.__input_players[_player_index].source = _source;
+    var _player = global.__input_players[_player_index];
+    if (_player.source != _source)
+    {
+        _player.last_input_time = current_time;
+    }
+    
+    _player.source = _source;
 }

--- a/scripts/input_source_hotswap_tick/input_source_hotswap_tick.gml
+++ b/scripts/input_source_hotswap_tick/input_source_hotswap_tick.gml
@@ -109,7 +109,7 @@ function __input_hotswap_tick_input(_player_index)
                     {
                         //Swap if the active source is available
                         if (__INPUT_DEBUG) __input_trace("Hotswapping player ", _player_index, " to gamepad ", _g);
-                        return { source : INPUT_SOURCE.GAMEPAD, gamepad : _g };
+                        return { source : INPUT_SOURCE.GAMEPAD, gamepad : _g };                
                     }
                 }
             }

--- a/scripts/input_source_hotswap_tick/input_source_hotswap_tick.gml
+++ b/scripts/input_source_hotswap_tick/input_source_hotswap_tick.gml
@@ -98,7 +98,7 @@ function __input_hotswap_tick_input(_player_index)
                 if (_active)
                 {
                     var _player = global.__input_players[_player_index];
-                    if ((_player.source == INPUT_SOURCE.GAMEPAD) && (_player.gamepad == _g))
+                    if (_player.gamepad == _g)
                     {
                         //Don't swap while the assigned gamepad is active
                         _player.last_input_time = current_time;

--- a/scripts/input_source_hotswap_tick/input_source_hotswap_tick.gml
+++ b/scripts/input_source_hotswap_tick/input_source_hotswap_tick.gml
@@ -37,10 +37,12 @@ function __input_hotswap_tick_input(_player_index)
     //Check gamepad input before keyboard input to correctly handle Android duplicating button presses with keyboard presses
     if (global.__input_gamepad_default_defined)
     {
+        var _player_gamepad = global.__input_players[_player_index].gamepad;
+        
         var _g = 0;
         repeat(gamepad_get_device_count())
         {
-            if (gamepad_is_connected(_g))
+            if (gamepad_is_connected(_g) && ((_player_gamepad == _g) || (input_source_is_available(INPUT_SOURCE.GAMEPAD, _g))))
             {
                 var _active = false;
                 
@@ -97,20 +99,16 @@ function __input_hotswap_tick_input(_player_index)
                 
                 if (_active)
                 {
-                    var _player = global.__input_players[_player_index];
                     if (_player.gamepad == _g)
                     {
-                        //Don't swap while the assigned gamepad is active
                         _player.last_input_time = current_time;
-                        return { source : INPUT_SOURCE.NONE };
+                    }
+                    else
+                    {
+                        if (__INPUT_DEBUG) __input_trace("Hotswapping player ", _player_index, " to gamepad ", _g);
                     }
                     
-                    if (input_source_is_available(INPUT_SOURCE.GAMEPAD, _g))
-                    {
-                        //Swap if the active source is available
-                        if (__INPUT_DEBUG) __input_trace("Hotswapping player ", _player_index, " to gamepad ", _g);
-                        return { source : INPUT_SOURCE.GAMEPAD, gamepad : _g };                
-                    }
+                    return { source : INPUT_SOURCE.GAMEPAD, gamepad : _g };
                 }
             }
             

--- a/scripts/input_source_hotswap_tick/input_source_hotswap_tick.gml
+++ b/scripts/input_source_hotswap_tick/input_source_hotswap_tick.gml
@@ -37,12 +37,12 @@ function __input_hotswap_tick_input(_player_index)
     //Check gamepad input before keyboard input to correctly handle Android duplicating button presses with keyboard presses
     if (global.__input_gamepad_default_defined)
     {
-        var _player_gamepad = global.__input_players[_player_index].gamepad;
+        var _player = global.__input_players[_player_index];
         
         var _g = 0;
         repeat(gamepad_get_device_count())
         {
-            if (gamepad_is_connected(_g) && ((_player_gamepad == _g) || (input_source_is_available(INPUT_SOURCE.GAMEPAD, _g))))
+            if (gamepad_is_connected(_g) && ((_player.gamepad == _g) || (input_source_is_available(INPUT_SOURCE.GAMEPAD, _g))))
             {
                 var _active = false;
                 

--- a/scripts/input_source_hotswap_tick/input_source_hotswap_tick.gml
+++ b/scripts/input_source_hotswap_tick/input_source_hotswap_tick.gml
@@ -100,7 +100,7 @@ function __input_hotswap_tick_input(_player_index)
                     var _player = global.__input_players[_player_index];
                     if ((_player.source == INPUT_SOURCE.GAMEPAD) && (_player.gamepad == _g))
                     {
-                        //Don't swap if the assigned source is active
+                        //Don't swap while the assigned gamepad is active
                         _player.last_input_time = current_time;
                         return { source : INPUT_SOURCE.NONE };
                     }

--- a/scripts/input_source_hotswap_tick/input_source_hotswap_tick.gml
+++ b/scripts/input_source_hotswap_tick/input_source_hotswap_tick.gml
@@ -104,8 +104,10 @@ function __input_hotswap_tick_input(_player_index)
                         _player.last_input_time = current_time;
                         return { source : INPUT_SOURCE.NONE };
                     }
-                    else if (input_source_is_available(INPUT_SOURCE.GAMEPAD, _g))
+                    
+                    if (input_source_is_available(INPUT_SOURCE.GAMEPAD, _g))
                     {
+                        //Swap if the active source is available
                         if (__INPUT_DEBUG) __input_trace("Hotswapping player ", _player_index, " to gamepad ", _g);
                         return { source : INPUT_SOURCE.GAMEPAD, gamepad : _g };
                     }

--- a/scripts/input_source_hotswap_tick/input_source_hotswap_tick.gml
+++ b/scripts/input_source_hotswap_tick/input_source_hotswap_tick.gml
@@ -40,8 +40,10 @@ function __input_hotswap_tick_input(_player_index)
         var _g = 0;
         repeat(gamepad_get_device_count())
         {
-            if (gamepad_is_connected(_g) && input_source_is_available(INPUT_SOURCE.GAMEPAD, _g))
+            if (gamepad_is_connected(_g))
             {
+                var _active = false;
+                
                 //Check buttons
                 if (input_gamepad_check(_g, gp_face1)
                 ||  input_gamepad_check(_g, gp_face2)
@@ -60,8 +62,7 @@ function __input_hotswap_tick_input(_player_index)
                 ||  (!input_gamepad_is_axis(_g, gp_shoulderlb) && input_gamepad_check(_g, gp_shoulderlb))
                 ||  (!input_gamepad_is_axis(_g, gp_shoulderrb) && input_gamepad_check(_g, gp_shoulderrb)))
                 {
-                    if (__INPUT_DEBUG) __input_trace("Hotswapping player ", _player_index, " to gamepad ", _g);
-                    return { source : INPUT_SOURCE.GAMEPAD, gamepad : _g };
+                    _active = true;
                 }
                 
                 //Check axes
@@ -75,8 +76,7 @@ function __input_hotswap_tick_input(_player_index)
                     ||  (abs(input_gamepad_value(_g, gp_axisrh)) > input_axis_threshold_get(gp_axisrh, _player_index).mini)
                     ||  (abs(input_gamepad_value(_g, gp_axisrv)) > input_axis_threshold_get(gp_axisrv, _player_index).mini))
                     {
-                        if (__INPUT_DEBUG) __input_trace("Hotswapping player ", _player_index, " to gamepad ", _g);
-                        return { source : INPUT_SOURCE.GAMEPAD, gamepad : _g };
+                        _active = true;
                     }
                 }
                 
@@ -91,8 +91,23 @@ function __input_hotswap_tick_input(_player_index)
                     ||  input_gamepad_check(_g, gp_paddle3)
                     ||  input_gamepad_check(_g, gp_paddle4))
                     {
+                        _active = true;
+                    }
+                }
+                
+                if (_active)
+                {
+                    var _player = global.__input_players[_player_index];
+                    if ((_player.source == INPUT_SOURCE.GAMEPAD) && (_player.gamepad == _g))
+                    {
+                        //Don't swap if the assigned source is active
+                        _player.last_input_time = current_time;
+                        return { source : INPUT_SOURCE.NONE };
+                    }
+                    else if (input_source_is_available(INPUT_SOURCE.GAMEPAD, _g))
+                    {
                         if (__INPUT_DEBUG) __input_trace("Hotswapping player ", _player_index, " to gamepad ", _g);
-                        return { source : INPUT_SOURCE.GAMEPAD, gamepad : _g };                
+                        return { source : INPUT_SOURCE.GAMEPAD, gamepad : _g };
                     }
                 }
             }


### PR DESCRIPTION
Improves 'last input' tracking and prevents an unassigned gamepad from taking precedence over an active gamepad source.

Fixes virtual controller scenarios where the source device still enumerates eg. x360ce, vJoy feeders and software using the ViGEm bus driver.