### PR TITLE
Fix crash on empty string verb

### DIFF
--- a/scripts/__input_class_player/__input_class_player.gml
+++ b/scripts/__input_class_player/__input_class_player.gml
@@ -256,6 +256,12 @@ function __input_class_player() constructor
             return undefined;
         }
         
+        if (_verb == "")
+        {
+            __input_error("Invalid \"verb\" argument (empty string)");
+            return undefined;
+        }
+        
         if (_alternate < 0)
         {
             __input_error("Invalid \"alternate\" argument (", _alternate, ")");


### PR DESCRIPTION
Disallows defining a verb as empty string #274