### PR TITLE
Smoke check invalid gamepad devices

### DIFF
--- a/scripts/__input_gamepad_set_blacklist/__input_gamepad_set_blacklist.gml
+++ b/scripts/__input_gamepad_set_blacklist/__input_gamepad_set_blacklist.gml
@@ -5,6 +5,19 @@ function __input_gamepad_set_blacklist()
     //Don't blacklist on preconfigured platforms
     if (!__INPUT_SDL2_SUPPORT) exit;
     
+    //Identify gamepad components
+    var _axis_count   = gamepad_axis_count(index); 
+    var _button_count = gamepad_button_count(index);
+    var _hat_count    = gamepad_hat_count(index);
+    
+    if ((_axis_count == 0) && (_button_count == 0) && (_hat_count == 0))
+    {
+        //Smoke check invalid devices
+        __input_trace("Warning! Controller ", index, " (VID+PID \"", vendor + product, "\" blacklisted: no button, axis or POV hat.");
+        blacklisted = true;
+        exit;
+    }
+    
     //Figure out which string to use to find the correct blacklist for the current OS
     var _os = undefined;
     switch(os_type)
@@ -58,13 +71,10 @@ function __input_gamepad_set_blacklist()
     
     //Block devices presenting in bad states
     if (!blacklisted)
-    {
-        var _a = gamepad_axis_count(index); 
-        var _b = gamepad_button_count(index);
-        
+    {        
         if (_os == "windows")
         {
-            if ((vendor == "7e05") && (product == "0920") && (_b == 23))
+            if ((vendor == "7e05") && (product == "0920") && (_button_count == 23))
             {
                 //Switch Pro Controller over USB
                 //Runs haywire if Steam is open
@@ -73,19 +83,10 @@ function __input_gamepad_set_blacklist()
             else if ((vendor == "4c05") && (product == "6802"))
             {
                 //PS3 Controller
-                //Bad mapping
-                if (((_a == 4) && (_b == 19)) //Bad driver
-                ||  ((_a == 8) && (_b == 0))) //DsHidMini gyro
+                if (((_axis_count == 4) && (_button_count == 19)) //Bad driver
+                ||  ((_axis_count == 8) && (_button_count == 0))) //DsHidMini gyro
                 {
-                    blacklisted = true;
-                }
-            }
-            else if ((vendor == "5e04") && (product == "e002"))
-            {
-                //Xbox One Wireless Controller over Bluetooth
-                //Duplicate DInput device on Windows 11
-                if ((os_version >= 655360) && (_b != 17))
-                {
+                    //Bad mapping
                     blacklisted = true;
                 }
             }
@@ -93,7 +94,7 @@ function __input_gamepad_set_blacklist()
         
         if (blacklisted)
         {
-            __input_trace("Warning! Controller manually blacklisted (VID+PID \"", vendor + product, "\", ", _b, " buttons and ", _a, " axes)");
+            __input_trace("Warning! Controller manually blacklisted (VID+PID \"", vendor + product, "\", ", _button_count, " buttons and ", _axis_count, " axes)");
         }
     }
 }

--- a/scripts/__input_gamepad_set_blacklist/__input_gamepad_set_blacklist.gml
+++ b/scripts/__input_gamepad_set_blacklist/__input_gamepad_set_blacklist.gml
@@ -24,22 +24,10 @@ function __input_gamepad_set_blacklist()
     
     //Check the platform blacklists to see if this gamepad is banned
     var _os_filter_dict  = global.__input_blacklist_dictionary[$ _os];
-    var _os_vid_dict     = is_struct(_os_filter_dict)? _os_filter_dict[$ "vid"                 ] : undefined;
-    var _os_vid_pid_dict = is_struct(_os_filter_dict)? _os_filter_dict[$ "vid+pid"             ] : undefined;
     var _os_guid_dict    = is_struct(_os_filter_dict)? _os_filter_dict[$ "guid"                ] : undefined;
     var _os_desc_array   = is_struct(_os_filter_dict)? _os_filter_dict[$ "description contains"] : undefined;
     
-    if (is_struct(_os_vid_dict) && variable_struct_exists(_os_vid_dict, vendor))
-    {
-        __input_trace("Warning! Controller is blacklisted (found by VID \"", vendor, "\")");
-        blacklisted = true;
-    }
-    else if (is_struct(_os_vid_pid_dict) && variable_struct_exists(_os_vid_pid_dict, vendor + product))
-    {
-        __input_trace("Warning! Controller is blacklisted (found by VID+PID \"", vendor + product, "\")");
-        blacklisted = true;
-    }
-    else if (is_struct(_os_guid_dict) && variable_struct_exists(_os_guid_dict, guid))
+    if (is_struct(_os_guid_dict) && variable_struct_exists(_os_guid_dict, guid))
     {
         __input_trace("Warning! Controller is blacklisted (found by GUID \"", guid, "\")");
         blacklisted = true;
@@ -76,24 +64,31 @@ function __input_gamepad_set_blacklist()
         
         if (_os == "windows")
         {
-            //Switch Pro Controller over USB
             if ((vendor == "7e05") && (product == "0920") && (_b == 23))
             {
+                //Switch Pro Controller over USB
+                //Runs haywire if Steam is open
                 blacklisted = true;
             }
-            else
+            else if ((vendor == "4c05") && (product == "6802"))
             {
                 //PS3 Controller
-                if ((vendor == "4c05") && (product == "6802"))
+                //Bad mapping
+                if (((_a == 4) && (_b == 19)) //Bad driver
+                ||  ((_a == 8) && (_b == 0))) //DsHidMini gyro
                 {
-                    if (((_a == 4) && (_b == 19)) //Bad driver
-                    ||  ((_a == 8) && (_b == 0))) //DsHidMini gyro
-                    {
-                        blacklisted = true;
-                    }
+                    blacklisted = true;
                 }
             }
-        
+            else if ((vendor == "5e04") && (product == "e002"))
+            {
+                //Xbox One Wireless Controller over Bluetooth
+                //Duplicate DInput device on Windows 11
+                if ((os_version >= 655360) && (_b != 17))
+                {
+                    blacklisted = true;
+                }
+            }
         }
         
         if (blacklisted)


### PR DESCRIPTION
Fix for duplicate (dead) DInput device on Xbox One Wireless controller over Bluetooth on Windows 11. Don't want to explicitly blacklist this device since it does work/require mapping on Win <10 and Win 10 with BLE firmware. Possible knock-on benefit for overeager uinput and Android drivers.

Removes unused `"vid"` and `"vid+pid"` blacklist categories. 