### PR TITLE
Adds `input_check_tapped`

### DIFF
--- a/input.yyp
+++ b/input.yyp
@@ -58,6 +58,7 @@
     {"id":{"name":"input_binding_set","path":"scripts/input_binding_set/input_binding_set.yy",},"order":0,},
     {"id":{"name":"input_cursor_elastic_remove","path":"scripts/input_cursor_elastic_remove/input_cursor_elastic_remove.yy",},"order":12,},
     {"id":{"name":"input_binding_set_safe","path":"scripts/input_binding_set_safe/input_binding_set_safe.yy",},"order":1,},
+    {"id":{"name":"input_check_tapped","path":"scripts/input_check_tapped/input_check_tapped.yy",},"order":17,},
     {"id":{"name":"__input_class_combo_definition","path":"scripts/__input_class_combo_definition/__input_class_combo_definition.yy",},"order":8,},
     {"id":{"name":"input_binding_swap","path":"scripts/input_binding_swap/input_binding_swap.yy",},"order":8,},
     {"id":{"name":"input_player_reset","path":"scripts/input_player_reset/input_player_reset.yy",},"order":4,},

--- a/scripts/input_check_tapped/input_check_tapped.gml
+++ b/scripts/input_check_tapped/input_check_tapped.gml
@@ -1,0 +1,33 @@
+/// @desc    Returns a boolean indicating whether the given verb passed a threshold this frame within a duration
+///          If an array of verbs is given then this function will return <true> if ANY verb passed a threshold this frame within a duration
+/// @param   verb/array
+/// @param   tapDuration
+/// @param   [tapThreshold=1]
+/// @param   [playerIndex=0]
+
+function input_check_tapped(_verb, _tap_duration, _tap_threshold = 1, _player_index = 0)
+{
+    __INPUT_VERIFY_PLAYER_INDEX
+    
+    if (is_array(_verb))
+    {
+        var _i = 0;
+        repeat(array_length(_verb))
+        {
+            if (input_check_tapped(_verb[_i], _tap_threshold, _player_index)) return true;
+            ++_i;
+        }
+        
+        return false;
+    }
+    
+    __INPUT_GET_VERB_STRUCT
+    
+    if (_verb_struct.__inactive || global.__input_cleared || !_verb_struct.held) return false;
+
+    if (!_verb_struct.analogue) return _verb_struct.press;
+
+    return ((_tap_duration >= (__input_get_time() - _verb_struct.press_time)) 
+         && (_tap_threshold > _verb_struct.previous_value)
+         && (_tap_threshold <= _verb_struct.value));
+}

--- a/scripts/input_check_tapped/input_check_tapped.gml
+++ b/scripts/input_check_tapped/input_check_tapped.gml
@@ -1,5 +1,5 @@
-/// @desc    Returns a boolean indicating whether the given verb passed a threshold this frame within a duration
-///          If an array of verbs is given then this function will return <true> if ANY verb passed a threshold this frame within a duration
+/// @desc    Returns a boolean indicating whether the given verb passed a threshold this frame within a given duration
+///          If an array of verbs is given then this function will return <true> if ANY verb passed a threshold this frame within a given duration
 /// @param   verb/array
 /// @param   tapDuration
 /// @param   [tapThreshold=1]

--- a/scripts/input_check_tapped/input_check_tapped.gml
+++ b/scripts/input_check_tapped/input_check_tapped.gml
@@ -27,7 +27,7 @@ function input_check_tapped(_verb, _tap_duration, _tap_threshold = 1, _player_in
 
     if (!_verb_struct.analogue) return _verb_struct.press;
 
-    return ((_tap_duration >= (__input_get_time() - _verb_struct.press_time)) 
-         && (_tap_threshold > _verb_struct.previous_value)
-         && (_tap_threshold <= _verb_struct.value));
+    return ((_tap_duration  >= (__input_get_time() - _verb_struct.press_time)) 
+         && (_tap_threshold >= _verb_struct.previous_value)
+         && (_tap_threshold <  _verb_struct.value));
 }

--- a/scripts/input_check_tapped/input_check_tapped.gml
+++ b/scripts/input_check_tapped/input_check_tapped.gml
@@ -28,6 +28,6 @@ function input_check_tapped(_verb, _tap_duration, _tap_threshold = 1, _player_in
     if (!_verb_struct.analogue) return _verb_struct.press;
 
     return ((_tap_duration  >= (__input_get_time() - _verb_struct.press_time)) 
-         && (_tap_threshold >= _verb_struct.previous_value)
-         && (_tap_threshold <  _verb_struct.value));
+         && (_tap_threshold >  _verb_struct.previous_value)
+         && (_tap_threshold <= _verb_struct.value));
 }

--- a/scripts/input_check_tapped/input_check_tapped.yy
+++ b/scripts/input_check_tapped/input_check_tapped.yy
@@ -1,0 +1,12 @@
+{
+  "isDnD": false,
+  "isCompatibility": false,
+  "parent": {
+    "name": "Checkers",
+    "path": "folders/Input/Checkers.yy",
+  },
+  "resourceVersion": "1.0",
+  "name": "input_check_tapped",
+  "tags": [],
+  "resourceType": "GMScript",
+}


### PR DESCRIPTION
Returns whether an input value crossed a threshold within a duration. Useful for checking “tapped” input on analogue sources such as a [Smash attack](https://www.ssbwiki.com/Smash_attack).