### PR TITLE
Adds `input_held_time_released`

### DIFF
--- a/input.yyp
+++ b/input.yyp
@@ -192,6 +192,7 @@
     {"id":{"name":"obj_test_binding_validity","path":"objects/obj_test_binding_validity/obj_test_binding_validity.yy",},"order":18,},
     {"id":{"name":"input_multiplayer_is_finished","path":"scripts/input_multiplayer_is_finished/input_multiplayer_is_finished.yy",},"order":18,},
     {"id":{"name":"input_profile_reset_bindings","path":"scripts/input_profile_reset_bindings/input_profile_reset_bindings.yy",},"order":7,},
+    {"id":{"name":"input_held_time_released","path":"scripts/input_held_time_released/input_held_time_released.yy",},"order":16,},
     {"id":{"name":"input_value_is_binding","path":"scripts/input_value_is_binding/input_value_is_binding.yy",},"order":3,},
     {"id":{"name":"input_profile_import","path":"scripts/input_profile_import/input_profile_import.yy",},"order":10,},
     {"id":{"name":"obj_example_mp_player","path":"objects/obj_example_mp_player/obj_example_mp_player.yy",},"order":4,},

--- a/scripts/input_held_time_released/input_held_time_released.gml
+++ b/scripts/input_held_time_released/input_held_time_released.gml
@@ -1,0 +1,15 @@
+/// @desc    Returns how long the current verb was held when released, the units of which is determined by INPUT_TIMER_MILLISECONDS
+///          This function returns a value less than 0 if the verb is not active or was not released
+/// @param   verb/array
+/// @param   [playerIndex=0]
+
+function input_held_time_released(_verb, _player_index = 0)
+{
+    __INPUT_VERIFY_PLAYER_INDEX
+    __INPUT_GET_VERB_STRUCT
+    
+    //Return a negative number if the verb is inactive, cleared, not released
+    if (_verb_struct.__inactive || global.__input_cleared || !_verb_struct.release) return -1;
+    
+    return max(0, (INPUT_TIMER_MILLISECONDS? global.__input_previous_current_time : global.__input_frame - 1) - _verb_struct.press_time);
+}

--- a/scripts/input_held_time_released/input_held_time_released.yy
+++ b/scripts/input_held_time_released/input_held_time_released.yy
@@ -1,0 +1,12 @@
+{
+  "isDnD": false,
+  "isCompatibility": false,
+  "parent": {
+    "name": "Checkers",
+    "path": "folders/Input/Checkers.yy",
+  },
+  "resourceVersion": "1.0",
+  "name": "input_held_time_released",
+  "tags": [],
+  "resourceType": "GMScript",
+}


### PR DESCRIPTION
Returns hold duration upon release, useful for timed input such as charged actions and taps (of the non-Smash variety)