### PR TITLE
Adds `input_check_tapped`

### DIFF
--- a/input.yyp
+++ b/input.yyp
@@ -58,6 +58,7 @@
     {"id":{"name":"input_binding_set","path":"scripts/input_binding_set/input_binding_set.yy",},"order":0,},
     {"id":{"name":"input_cursor_elastic_remove","path":"scripts/input_cursor_elastic_remove/input_cursor_elastic_remove.yy",},"order":12,},
     {"id":{"name":"input_binding_set_safe","path":"scripts/input_binding_set_safe/input_binding_set_safe.yy",},"order":1,},
+    {"id":{"name":"input_check_tapped","path":"scripts/input_check_tapped/input_check_tapped.yy",},"order":17,},
     {"id":{"name":"__input_class_combo_definition","path":"scripts/__input_class_combo_definition/__input_class_combo_definition.yy",},"order":8,},
     {"id":{"name":"input_binding_swap","path":"scripts/input_binding_swap/input_binding_swap.yy",},"order":8,},
     {"id":{"name":"input_player_reset","path":"scripts/input_player_reset/input_player_reset.yy",},"order":4,},

--- a/scripts/__input_class_verb_state/__input_class_verb_state.gml
+++ b/scripts/__input_class_verb_state/__input_class_verb_state.gml
@@ -40,6 +40,9 @@ function __input_class_verb_state() constructor
     long_held_time    = -1;
     long_release_time = -1;
     
+    tap_press = false;
+    tap_time  = -1; 
+    
     //Used for "toggle momentary" accessibility feature 
     __toggle_prev_value = 0.0;
     __toggle_value      = 0.0;
@@ -148,6 +151,8 @@ function __input_class_verb_state() constructor
                 long_held      = true;
                 long_held_time = _time;
             }
+            
+            tap_press = (((_time - press_time) < INPUT_TAP_DEFAULT_TIME) && (previous_value < INPUT_TAP_THRESHOLD) && (value >= INPUT_TAP_THRESHOLD));
         }
         else
         {
@@ -158,12 +163,14 @@ function __input_class_verb_state() constructor
             }
             
             long_held = false;
+            tap_press = false;
         }
         
         previous_held = held;
         
         if (double_held) double_held_time = _time;
-        if (long_held) long_held_time = _time;
+        if (long_held)   long_held_time   = _time;
+        if (tap_press)   tap_time         = _time;
         
         __inactive = (__group_inactive || __consumed);
     }

--- a/scripts/__input_config_verbs/__input_config_verbs.gml
+++ b/scripts/__input_config_verbs/__input_config_verbs.gml
@@ -5,23 +5,31 @@ INPUT_VERB_GROUPS = {
 };
 
 //Default time before input_check_repeat() returns <true>
-//(Whether this is in frames or milliseconds is controlled by INPUT_TIMER_MILLISECONDS above)
+//(Whether this is in frames or milliseconds is controlled by INPUT_TIMER_MILLISECONDS)
 #macro INPUT_REPEAT_DEFAULT_DELAY  10
 
 //Default time between a verb being activated and the first time input_check_repeat() returns <true>
-//(Whether this is in frames or milliseconds is controlled by INPUT_TIMER_MILLISECONDS above)
+//(Whether this is in frames or milliseconds is controlled by INPUT_TIMER_MILLISECONDS)
 #macro INPUT_REPEAT_DEFAULT_PREDELAY  30
 
 //Time before input_check_long() returns <true>
-//(Whether this is in frames or milliseconds is controlled by INPUT_TIMER_MILLISECONDS above)
+//(Whether this is in frames or milliseconds is controlled by INPUT_TIMER_MILLISECONDS)
 #macro INPUT_LONG_DELAY  10
 
 //Delay between key presses for it to register as a double press
-//(Whether this is in frames or milliseconds is controlled by INPUT_TIMER_MILLISECONDS above)
+//(Whether this is in frames or milliseconds is controlled by INPUT_TIMER_MILLISECONDS)
 #macro INPUT_DOUBLE_DELAY  12
 
+//The threshold for a verb to register as a tap from analogue sources
+//Value should be from 0 to 1.0
+#macro INPUT_TAP_THRESHOLD  0.8
+
+//Default time limit between a verb being activated and reaching the threshold for tap activation
+//(Whether this is in frames or milliseconds is controlled by INPUT_TIMER_MILLISECONDS)
+#macro INPUT_TAP_DEFAULT_TIME  2
+
 //Default time limit between the first and last key press for chord activation
-//(Whether this is in frames or milliseconds is controlled by INPUT_TIMER_MILLISECONDS above)
+//(Whether this is in frames or milliseconds is controlled by INPUT_TIMER_MILLISECONDS)
 #macro INPUT_CHORD_DEFAULT_TIME  4
 
 //Whether to clamp 2D input to a maximum distance of 1 unit

--- a/scripts/input_check_tapped/input_check_tapped.gml
+++ b/scripts/input_check_tapped/input_check_tapped.gml
@@ -1,0 +1,36 @@
+/// @desc    Returns a boolean indicating whether the given verb was tapped this frame
+///          If an array of verbs is given then this function will return <true> if ANY verb was tapped
+///          If a buffer duration is specified then this function will return <true> if the verb has been tapped at any point within that timeframe
+/// @param   verb/array
+/// @param   [playerIndex=0]
+/// @param   [bufferDuration=0]
+
+function input_check_tapped(_verb, _player_index = 0, _buffer_duration = 0)
+{
+    __INPUT_VERIFY_PLAYER_INDEX
+    
+    if (is_array(_verb))
+    {
+        var _i = 0;
+        repeat(array_length(_verb))
+        {
+            if (input_check_tapped(_verb[_i], _player_index, _buffer_duration)) return true;
+            ++_i;
+        }
+        
+        return false;
+    }
+    
+    __INPUT_GET_VERB_STRUCT
+    
+    if (_verb_struct.__inactive) return false;
+    
+    if (_buffer_duration <= 0)
+    {
+        return ((global.__input_cleared)? false : _verb_struct.tap_press);
+    }
+    else
+    {
+        return ((_verb_struct.tap_time >= 0) && ((__input_get_time() - _verb_struct.tap_time) <= _buffer_duration));
+    }
+}

--- a/scripts/input_check_tapped/input_check_tapped.yy
+++ b/scripts/input_check_tapped/input_check_tapped.yy
@@ -1,0 +1,12 @@
+{
+  "isDnD": false,
+  "isCompatibility": false,
+  "parent": {
+    "name": "Checkers",
+    "path": "folders/Input/Checkers.yy",
+  },
+  "resourceVersion": "1.0",
+  "name": "input_check_tapped",
+  "tags": [],
+  "resourceType": "GMScript",
+}


### PR DESCRIPTION
Returns whether an input value crossed a threshold within a duration. Useful for checking “tapped” input on analogue sources such as a [Smash attack](https://www.ssbwiki.com/Smash_attack).