### PR TITLE
Hotswap fix for PlayStation controllers on Windows

### DIFF
--- a/objects/obj_gamepad_tester/Draw_0.gml
+++ b/objects/obj_gamepad_tester/Draw_0.gml
@@ -96,6 +96,7 @@ draw_rectangle(488, 0, 490, room_height, false);
 
 var _string = "";
 
+_string += "Player gamepad: " + string(input_player_get_gamepad()) + "\n\n";
 _string += "GUID = \"" + gamepad_get_guid(input_player_get_gamepad()) + "\"\n";
 _string += "Input gamepad desc = \"" + input_gamepad_get_description(input_player_get_gamepad()) + "\"\n";
 _string += "Input gamepad type = \"" + input_gamepad_get_type(input_player_get_gamepad()) + "\"\n";
@@ -126,6 +127,6 @@ repeat(255)
 _string += "mouse = " + string(mouse_x) + "," + string(mouse_y) + "\n";
 _string += "device = " + string(device_mouse_x(0)) + "," + string(device_mouse_y(0)) + "\n";
 
-draw_text(500, 70, _string);
+draw_text(500, 10, _string);
 
 draw_text(500, 740, current_time);

--- a/scripts/__input_hotswap_tick/__input_hotswap_tick.gml
+++ b/scripts/__input_hotswap_tick/__input_hotswap_tick.gml
@@ -73,8 +73,11 @@ function __input_hotswap_tick_input()
                 //Check axes
                 if  (INPUT_HOTSWAP_ON_GAMEPAD_AXIS)
                 {
-                    if ((abs(input_gamepad_value(_g, gp_shoulderlb)) > input_axis_threshold_get(gp_shoulderlb, 0).mini)
-                    ||  (abs(input_gamepad_value(_g, gp_shoulderrb)) > input_axis_threshold_get(gp_shoulderrb, 0).mini)
+                    //Ignore non-zero trigger axis on PlayStation controllers temporarily blocked with DS4Win, DualSenseX (HidHide) or Steam Input
+                    var _playstation_on_windows = ((os_type == os_windows) && !__INPUT_ON_WEB && (global.__input_gamepads[@ _g] != undefined) && (string_pos("ps", global.__input_gamepads[@ _g].simple_type) == 1));
+
+                    if ((abs(input_gamepad_value(_g, gp_shoulderlb)) > max(input_axis_threshold_get(gp_shoulderlb, 0).mini, (_playstation_on_windows? 0.51 : 0)))
+                    ||  (abs(input_gamepad_value(_g, gp_shoulderrb)) > max(input_axis_threshold_get(gp_shoulderrb, 0).mini, (_playstation_on_windows? 0.51 : 0)))
                     ||  (abs(input_gamepad_value(_g, gp_axislv)) > input_axis_threshold_get(gp_axislv, 0).mini)
                     ||  (abs(input_gamepad_value(_g, gp_axislh)) > input_axis_threshold_get(gp_axislh, 0).mini)
                     ||  (abs(input_gamepad_value(_g, gp_axislv)) > input_axis_threshold_get(gp_axislv, 0).mini)


### PR DESCRIPTION
via DS4Win, DualSenseX (HIDHide) and Steam Input