### PR TITLE
Block input while window out of focus

### DIFF
--- a/objects/obj_gamepad_tester/Draw_0.gml
+++ b/objects/obj_gamepad_tester/Draw_0.gml
@@ -1,3 +1,5 @@
+draw_set_color(global.__input_window_focus? c_white : c_gray);
+
 var _string = "";
 
 _string += "Gamepad " + string(test_index) + " of " + string(gamepad_get_device_count()) + ", \"" + string(gamepad_get_description(test_index)) + "\"\n\n";

--- a/scripts/__input_class_gamepad/__input_class_gamepad.gml
+++ b/scripts/__input_class_gamepad/__input_class_gamepad.gml
@@ -182,13 +182,13 @@ function __input_class_gamepad(_index) constructor
         return _mapping;
     }
     
-    static tick = function()
+    static tick = function(_clear = false)
     {
         var _gamepad = index;
         var _i = 0;
         repeat(array_length(mapping_array))
         {
-            with(mapping_array[_i]) tick(_gamepad);
+            with(mapping_array[_i]) tick(_gamepad, _clear);
             ++_i;
         }
         

--- a/scripts/__input_class_gamepad_mapping/__input_class_gamepad_mapping.gml
+++ b/scripts/__input_class_gamepad_mapping/__input_class_gamepad_mapping.gml
@@ -39,7 +39,7 @@ function __input_class_gamepad_mapping(_gm, _raw, _type, _sdl_name) constructor
     press         = false;
     release       = false;
     
-    static tick = function(_gamepad)
+    static tick = function(_gamepad, _clear)
     {
         held_previous = held;
         value         = 0.0;
@@ -47,52 +47,55 @@ function __input_class_gamepad_mapping(_gm, _raw, _type, _sdl_name) constructor
         press         = false;
         release       = false;
         
-        switch(type)
-        {
-            case __INPUT_MAPPING.BUTTON:
-                value = gamepad_button_check(_gamepad, raw);
-            break;
-            
-            case __INPUT_MAPPING.AXIS:
-                value = gamepad_axis_value(_gamepad, raw);
-            break;
-            
-            case __INPUT_MAPPING.HAT:
-                value = ((gamepad_hat_value(_gamepad, raw) & hat_mask) > 0);
-            break;
-            
-            case __INPUT_MAPPING.HAT_TO_AXIS:
-                value = ((gamepad_hat_value( _gamepad, raw_positive) & hat_mask_positive) > 0) - ((gamepad_hat_value(_gamepad, raw_negative) & hat_mask_negative) > 0);
-            break;
-            
-            case __INPUT_MAPPING.BUTTON_TO_AXIS:
-                var _positive = gamepad_button_check(_gamepad, raw_positive);
-                var _negative = gamepad_button_check(_gamepad, raw_negative);
-                
-                value = _positive - _negative;
-            break;                
-            
-            case __INPUT_MAPPING.SPLIT_AXIS:
-                var _positive = gamepad_axis_value(_gamepad, raw_positive);
-                var _negative = gamepad_axis_value(_gamepad, raw_negative);
-                
-                if (positive_clamp_negative) _positive = clamp(_positive, -1, 0);
-                if (positive_clamp_positive) _positive = clamp(_positive,  0, 1);
-                if (negative_clamp_negative) _negative = clamp(_negative, -1, 0);
-                if (negative_clamp_positive) _negative = clamp(_negative,  0, 1);
-                
-                value = _positive - _negative;
-            break;
+        if (!_clear)
+        {        
+            switch(type)
+            {
+                case __INPUT_MAPPING.BUTTON:
+                    value = gamepad_button_check(_gamepad, raw);
+                break;
+                    
+                case __INPUT_MAPPING.AXIS:
+                    value = gamepad_axis_value(_gamepad, raw);
+                break;
+                    
+                case __INPUT_MAPPING.HAT:
+                    value = ((gamepad_hat_value(_gamepad, raw) & hat_mask) > 0);
+                break;
+                    
+                case __INPUT_MAPPING.HAT_TO_AXIS:
+                    value = ((gamepad_hat_value( _gamepad, raw_positive) & hat_mask_positive) > 0) - ((gamepad_hat_value(_gamepad, raw_negative) & hat_mask_negative) > 0);
+                break;
+                    
+                case __INPUT_MAPPING.BUTTON_TO_AXIS:
+                    var _positive = gamepad_button_check(_gamepad, raw_positive);
+                    var _negative = gamepad_button_check(_gamepad, raw_negative);
+                    
+                    value = _positive - _negative;
+                break;
+                    
+                case __INPUT_MAPPING.SPLIT_AXIS:
+                    var _positive = gamepad_axis_value(_gamepad, raw_positive);
+                    var _negative = gamepad_axis_value(_gamepad, raw_negative);
+                    
+                    if (positive_clamp_negative) _positive = clamp(_positive, -1, 0);
+                    if (positive_clamp_positive) _positive = clamp(_positive,  0, 1);
+                    if (negative_clamp_negative) _negative = clamp(_negative, -1, 0);
+                    if (negative_clamp_positive) _negative = clamp(_negative,  0, 1);
+                    
+                    value = _positive - _negative;
+                break;
+            }
+             
+            if (limited_range)  value = 2*value - 1; //Expand 0 -> 1 range to the full -1 -> +1
+            if (extended_range) value = 0.5 + 0.5*value; //Reduce -1 -> +1 range to 0 -> 1
+            if (clamp_negative) value = clamp(value, -1, 0);
+            if (clamp_positive) value = clamp(value,  0, 1);
+            if (invert)         value = 1 - value;
+            if (reverse)        value = -value;
+                    
+            held = (abs(value) > __INPUT_HOLD_THRESHOLD);
         }
-        
-        if (limited_range)  value = 2*value - 1; //Expand 0 -> 1 range to the full -1 -> +1
-        if (extended_range) value = 0.5 + 0.5*value; //Reduce -1 -> +1 range to 0 -> 1
-        if (clamp_negative) value = clamp(value, -1, 0);
-        if (clamp_positive) value = clamp(value,  0, 1);
-        if (invert)         value = 1 - value;
-        if (reverse)        value = -value;
-        
-        held = (abs(value) > __INPUT_HOLD_THRESHOLD);
         
         if (held_previous != held)
         {

--- a/scripts/__input_config_general/__input_config_general.gml
+++ b/scripts/__input_config_general/__input_config_general.gml
@@ -5,6 +5,9 @@
 //Maximum number of alternate bindings per verb per profile
 #macro INPUT_MAX_ALTERNATE_BINDINGS  2
 
+//Whether to allow input while game window is out of focus on desktop platforms
+#macro INPUT_ALLOW_OUT_OF_FOCUS false
+
 //Set to true to use milliseconds instead of frames throughout the library
 #macro INPUT_TIMER_MILLISECONDS  false
 

--- a/scripts/__input_initialize/__input_initialize.gml
+++ b/scripts/__input_initialize/__input_initialize.gml
@@ -55,7 +55,8 @@ function __input_initialize()
     global.__input_cleared = false;
     
     //Windows focus tracking
-    global.__input_window_focus = true;
+    global.__input_window_focus           = true;
+     global.__input_window_focus_previous = true;
     
     //Accessibility state
     global.__input_toggle_momentary_dict  = {};

--- a/scripts/__input_initialize/__input_initialize.gml
+++ b/scripts/__input_initialize/__input_initialize.gml
@@ -55,8 +55,8 @@ function __input_initialize()
     global.__input_cleared = false;
     
     //Windows focus tracking
-    global.__input_window_focus           = true;
-     global.__input_window_focus_previous = true;
+    global.__input_window_focus          = true;
+    global.__input_window_focus_previous = true;
     
     //Accessibility state
     global.__input_toggle_momentary_dict  = {};

--- a/scripts/__input_system_tick/__input_system_tick.gml
+++ b/scripts/__input_system_tick/__input_system_tick.gml
@@ -241,25 +241,22 @@ function __input_system_tick()
             var _pointer_x = _old_x;
             var _pointer_y = _old_y;
             
-            if (global.__input_window_focus)
+            switch(_m)
             {
-                switch(_m)
-                {
-                    case INPUT_COORD_SPACE.ROOM:
-                        _pointer_x = device_mouse_x(global.__input_pointer_index);
-                        _pointer_y = device_mouse_y(global.__input_pointer_index);
-                    break;
-                    
-                    case INPUT_COORD_SPACE.GUI:
-                        _pointer_x = device_mouse_x_to_gui(global.__input_pointer_index);
-                        _pointer_y = device_mouse_y_to_gui(global.__input_pointer_index);
-                    break;
-                    
-                    case INPUT_COORD_SPACE.DISPLAY:
-                        _pointer_x = device_mouse_raw_x(global.__input_pointer_index);
-                        _pointer_y = device_mouse_raw_y(global.__input_pointer_index);
-                    break;
-                }
+                case INPUT_COORD_SPACE.ROOM:
+                    _pointer_x = device_mouse_x(global.__input_pointer_index);
+                    _pointer_y = device_mouse_y(global.__input_pointer_index);
+                break;
+                 
+                case INPUT_COORD_SPACE.GUI:
+                    _pointer_x = device_mouse_x_to_gui(global.__input_pointer_index);
+                    _pointer_y = device_mouse_y_to_gui(global.__input_pointer_index);
+                break;
+                
+                case INPUT_COORD_SPACE.DISPLAY:
+                    _pointer_x = device_mouse_raw_x(global.__input_pointer_index);
+                    _pointer_y = device_mouse_raw_y(global.__input_pointer_index);
+                break;
             }
             
             //Only detect movement in the display coordinate space so that moving a room's view, or moving the window, doesn't trigger movement
@@ -277,8 +274,9 @@ function __input_system_tick()
     
     global.__input_pointer_moved = _moved;
     
-    
+    //Windows touchpad tracking
     global.__input_tap_click = false;
+    
     if (os_type == os_windows)
     {
         //Track clicks from touchpad and touchscreen taps (system-setting dependent)

--- a/scripts/__input_system_tick/__input_system_tick.gml
+++ b/scripts/__input_system_tick/__input_system_tick.gml
@@ -241,22 +241,25 @@ function __input_system_tick()
             var _pointer_x = _old_x;
             var _pointer_y = _old_y;
             
-            switch(_m)
+            if (global.__input_window_focus)
             {
-                case INPUT_COORD_SPACE.ROOM:
-                    _pointer_x = device_mouse_x(global.__input_pointer_index);
-                    _pointer_y = device_mouse_y(global.__input_pointer_index);
-                break;
-                
-                case INPUT_COORD_SPACE.GUI:
-                    _pointer_x = device_mouse_x_to_gui(global.__input_pointer_index);
-                    _pointer_y = device_mouse_y_to_gui(global.__input_pointer_index);
-                break;
-                
-                case INPUT_COORD_SPACE.DISPLAY:
-                    _pointer_x = device_mouse_raw_x(global.__input_pointer_index);
-                    _pointer_y = device_mouse_raw_y(global.__input_pointer_index);
-                break;
+                switch(_m)
+                {
+                    case INPUT_COORD_SPACE.ROOM:
+                        _pointer_x = device_mouse_x(global.__input_pointer_index);
+                        _pointer_y = device_mouse_y(global.__input_pointer_index);
+                    break;
+                    
+                    case INPUT_COORD_SPACE.GUI:
+                        _pointer_x = device_mouse_x_to_gui(global.__input_pointer_index);
+                        _pointer_y = device_mouse_y_to_gui(global.__input_pointer_index);
+                    break;
+                    
+                    case INPUT_COORD_SPACE.DISPLAY:
+                        _pointer_x = device_mouse_raw_x(global.__input_pointer_index);
+                        _pointer_y = device_mouse_raw_y(global.__input_pointer_index);
+                    break;
+                }
             }
             
             //Only detect movement in the display coordinate space so that moving a room's view, or moving the window, doesn't trigger movement
@@ -274,7 +277,7 @@ function __input_system_tick()
     
     global.__input_pointer_moved = _moved;
     
-    //Windows mouse extensions
+    
     global.__input_tap_click = false;
     if (os_type == os_windows)
     {


### PR DESCRIPTION
Adds `INPUT_ALLOW_OUT_OF_FOCUS` macro, whether to allow input while game window is out of focus on desktop platforms

When `false` (default):
- Prevents clicks from out of focus from registering input on all desktop platforms
- Prevents gamepads registering input while window is out of focus on MacOS and Linux (this is default behaviour on Windows)