### PR TITLE
Clamp gamepad input value

### DIFF
--- a/scripts/__input_class_gamepad_mapping/__input_class_gamepad_mapping.gml
+++ b/scripts/__input_class_gamepad_mapping/__input_class_gamepad_mapping.gml
@@ -92,8 +92,9 @@ function __input_class_gamepad_mapping(_gm, _raw, _type, _sdl_name) constructor
         if (invert)         value = 1 - value;
         if (reverse)        value = -value;
         
-        held = (abs(value) > __INPUT_HOLD_THRESHOLD);
+        value = clamp(value, -1, 1);
         
+        held = (abs(value) > __INPUT_HOLD_THRESHOLD);
         if (held_previous != held)
         {
             if (held)


### PR DESCRIPTION
Bad (or simply incorrect) mappings, especially on Linux (sometimes our fault) and Android (usually GM's fault), may produce wildly out-of-bound values for gamepad input