### PR TITLE
XInput trigger calibration

### DIFF
--- a/scripts/__input_class_gamepad/__input_class_gamepad.gml
+++ b/scripts/__input_class_gamepad/__input_class_gamepad.gml
@@ -10,6 +10,7 @@ function __input_class_gamepad(_index) constructor
     sdl2_definition = undefined;
     guessed_type    = false;
     blacklisted     = false;
+    scale_trigger   = false;
     
     vendor  = undefined;
     product = undefined;
@@ -206,6 +207,16 @@ function __input_class_gamepad(_index) constructor
     
     static tick = function(_clear = false)
     {
+        //Recalibrate XInput triggers
+        if (scale_trigger && ((gamepad_axis_value(index, __XINPUT_AXIS_LT) > 0.25) || (gamepad_axis_value(index, __XINPUT_AXIS_RT) > 0.25)))
+        {
+            //Trigger value exceeds limited range, set range to "normal" scale (0 to 255/256)
+            with mapping_gm_to_raw[$ gp_shoulderlb] scale = 255;
+            with mapping_gm_to_raw[$ gp_shoulderrb] scale = 255;
+            scale_trigger = false;
+            __input_trace("Recalibrated XInput trigger scale for gamepad ", index);
+        }
+        
         var _scan = (current_time > __scan_start_time);
         var _gamepad = index;
         var _i = 0;

--- a/scripts/__input_class_gamepad_mapping/__input_class_gamepad_mapping.gml
+++ b/scripts/__input_class_gamepad_mapping/__input_class_gamepad_mapping.gml
@@ -17,6 +17,7 @@ function __input_class_gamepad_mapping(_gm, _raw, _type, _sdl_name) constructor
     limited_range    = false;
     extended_range   = false;
     hat_mask         = undefined;
+    scale            = 256;
     
     //Hat-on-axis and split axis
     raw_negative = undefined;
@@ -101,7 +102,7 @@ function __input_class_gamepad_mapping(_gm, _raw, _type, _sdl_name) constructor
             if (invert)         value = 1 - value;
             if (reverse)        value = -value;
                   
-            value = clamp(value, -1, 1);
+            value = clamp((256/scale)*value, -1, 1);
             
             if (__value_previous == undefined)
             {

--- a/scripts/__input_class_source/__input_class_source.gml
+++ b/scripts/__input_class_source/__input_class_source.gml
@@ -87,7 +87,7 @@ function __input_class_source(_source, _gamepad = undefined) constructor
                     return false;
                 }
                 
-                if (_gamepad.xinput && ((_raw == 4106) || (_raw == 4107)))
+                if (_gamepad.xinput && ((_raw == __XINPUT_AXIS_LT) || (_raw == __XINPUT_AXIS_RT)))
                 {
                     //Except XInput trigger values from range checks
                     return true;

--- a/scripts/__input_gamepad_set_mapping/__input_gamepad_set_mapping.gml
+++ b/scripts/__input_gamepad_set_mapping/__input_gamepad_set_mapping.gml
@@ -235,10 +235,11 @@ function __input_gamepad_set_mapping()
         set_mapping(gp_axislv, 1, __INPUT_MAPPING.AXIS, "lefty").reverse = true;
         set_mapping(gp_axisrh, 2, __INPUT_MAPPING.AXIS, "rightx");
         set_mapping(gp_axisrv, 3, __INPUT_MAPPING.AXIS, "righty").reverse = true;
-            
-        //This bit is weird but it enables analogue input from triggers so...
-        set_mapping(gp_shoulderlb, 4106, __INPUT_MAPPING.AXIS, "lefttrigger");
-        set_mapping(gp_shoulderrb, 4107, __INPUT_MAPPING.AXIS, "righttrigger");
+        
+        //Set initial trigger scale per Xbox One and Series controllers over USB (0 to 63/256)
+        set_mapping(gp_shoulderlb, __XINPUT_AXIS_LT, __INPUT_MAPPING.AXIS, "lefttrigger").scale  = 63;
+        set_mapping(gp_shoulderrb, __XINPUT_AXIS_RT, __INPUT_MAPPING.AXIS, "righttrigger").scale = 63;
+        scale_trigger = true;
         
         exit;
     }

--- a/scripts/__input_system/__input_system.gml
+++ b/scripts/__input_system/__input_system.gml
@@ -52,6 +52,10 @@
 #macro gp_paddle3   32894
 #macro gp_paddle4   32895
 
+//Enables analogue axis checks from triggers on XInput
+#macro __XINPUT_AXIS_LT  4106
+#macro __XINPUT_AXIS_RT  4107
+
 //Unfortunately, versions prior to v5.2 used these values for extended gamepad constants
 //They collide with GameMaker's native constants for gamepad axis values for PS4/PS5 controllers
 #macro __INPUT_LEGACY_GP_GUIDE     32789 //gp_axis_acceleration_x


### PR DESCRIPTION
Fixes an off-by-one bug on XInput trigger axis range

Also, ad-hoc fix for axis range on wired Xbox One and Series controllers. Latter is an upstream XInput issue and has been reported to YYG though likely nothing can or will be done as it is a driver level problem that exhibits (for example) on Unity and Unreal games as well

Before patch:
- Xbox One and Series controllers over USB always report very incorrect trigger values (0 to 63/256)
- Other XInput controllers always report slightly incorrect trigger values (0 to 255/256)

After:
- Xbox One and Series controllers over USB always report correct trigger values (0 to 1)
- Other XInput controllers report incorrect trigger values (0 to 256/63, clamped) until a one-time quarter pull (or greater) on either trigger, upon which they are recalibrated to report correctly thereafter (0 to 1)