### PR TITLE
Fix gamepad input registering while out of focus on Mac and Linux

### DIFF
--- a/scripts/__input_class_gamepad/__input_class_gamepad.gml
+++ b/scripts/__input_class_gamepad/__input_class_gamepad.gml
@@ -93,6 +93,7 @@ function __input_class_gamepad(_index) constructor
     /// @param GMconstant
     static get_held = function(_gm)
     {
+        if (!INPUT_ALLOW_OUT_OF_FOCUS && !global.__input_window_focus) return false;
         if (!custom_mapping) return gamepad_button_check(index, _gm);
         var _mapping = mapping_gm_to_raw[$ _gm];
         if (_mapping == undefined) return false;
@@ -102,6 +103,7 @@ function __input_class_gamepad(_index) constructor
     /// @param GMconstant
     static get_pressed = function(_gm)
     {
+        if (!INPUT_ALLOW_OUT_OF_FOCUS && !global.__input_window_focus) return false;
         if (!custom_mapping) return gamepad_button_check_pressed(index, _gm);
         var _mapping = mapping_gm_to_raw[$ _gm];
         if (_mapping == undefined) return false;
@@ -111,6 +113,7 @@ function __input_class_gamepad(_index) constructor
     /// @param GMconstant
     static get_released = function(_gm)
     {
+        if (!INPUT_ALLOW_OUT_OF_FOCUS && !global.__input_window_focus) return false;
         if (!custom_mapping) return gamepad_button_check_released(index, _gm);
         var _mapping = mapping_gm_to_raw[$ _gm];
         if (_mapping == undefined) return false;
@@ -120,6 +123,7 @@ function __input_class_gamepad(_index) constructor
     /// @param GMconstant
     static get_value = function(_gm)
     {
+        if (!INPUT_ALLOW_OUT_OF_FOCUS && !global.__input_window_focus) return 0.0;
         if (!custom_mapping)
         {
             if ((_gm == gp_axislh) || (_gm == gp_axislv) || (_gm == gp_axisrh) || (_gm == gp_axisrv))
@@ -219,7 +223,7 @@ function __input_class_gamepad(_index) constructor
         return _mapping;
     }
     
-    static tick = function(_clear = false)
+    static tick = function()
     {
         //Recalibrate XInput triggers
         if (scale_trigger && ((gamepad_axis_value(index, __XINPUT_AXIS_LT) > 0.25) || (gamepad_axis_value(index, __XINPUT_AXIS_RT) > 0.25)))
@@ -236,7 +240,7 @@ function __input_class_gamepad(_index) constructor
         var _i = 0;
         repeat(array_length(mapping_array))
         {
-            with(mapping_array[_i]) tick(_gamepad, _clear, _scan);
+            with(mapping_array[_i]) tick(_gamepad, _scan);
             ++_i;
         }
         

--- a/scripts/__input_class_gamepad_mapping/__input_class_gamepad_mapping.gml
+++ b/scripts/__input_class_gamepad_mapping/__input_class_gamepad_mapping.gml
@@ -43,7 +43,7 @@ function __input_class_gamepad_mapping(_gm, _raw, _type, _sdl_name) constructor
     __value_previous = undefined;
     __value_delta    = 0.0;
     
-    static tick = function(_gamepad, _clear, _scan)
+    static tick = function(_gamepad, _scan)
     {
         held_previous = held;
         if (__value_previous != undefined) __value_previous = value; //Don't update the previous value until we get our first scanned value
@@ -55,7 +55,7 @@ function __input_class_gamepad_mapping(_gm, _raw, _type, _sdl_name) constructor
         
         if (!_scan) return;
         
-        if (!_clear)
+        if (INPUT_ALLOW_OUT_OF_FOCUS || global.__input_window_focus)
         {        
             switch(type)
             {

--- a/scripts/__input_system_tick/__input_system_tick.gml
+++ b/scripts/__input_system_tick/__input_system_tick.gml
@@ -391,8 +391,6 @@ function __input_system_tick()
         var _device_change = max(0, gamepad_get_device_count() - array_length(INPUT_GAMEPAD))
         repeat(_device_change) array_push(INPUT_GAMEPAD, new __input_class_source(__INPUT_SOURCE.GAMEPAD, array_length(INPUT_GAMEPAD)));
         
-        var _clear_gamepads = (!INPUT_ALLOW_OUT_OF_FOCUS && !global.__input_window_focus);
-        
         var _g = 0;
         repeat(array_length(global.__input_gamepads))
         {
@@ -410,7 +408,7 @@ function __input_system_tick()
                     }
                     else
                     {
-                        _gamepad.tick(_clear_gamepads);
+                        _gamepad.tick();
                     }
                 }
                 else


### PR DESCRIPTION
Apparently failed to thoroughly test this when focus was added (m+kb are fine)