### PR TITLE
Fixes crashing on HTML5

### DIFF
--- a/scripts/__input_initialize/__input_initialize.gml
+++ b/scripts/__input_initialize/__input_initialize.gml
@@ -15,7 +15,7 @@ function __input_initialize()
     
     __input_trace("Welcome to Input by @jujuadams and @offalynne! This is version ", __INPUT_VERSION, ", ", __INPUT_DATE);
     
-    global.__input_use_is_instanceof = (string_copy(GM_runtime_version, 1, 4) == "2023");
+    global.__input_use_is_instanceof = (!__INPUT_ON_WEB) && (string_copy(GM_runtime_version, 1, 4) == "2023");
     if (global.__input_use_is_instanceof) __input_trace("On runtime ", GM_runtime_version, ", using is_instanceof()");
     
     //Attempt to set up a time source for slick automatic input handling


### PR DESCRIPTION
For some reason, `is_instanceof` just doesn't exist on HTML5? Kind of an oversight there, but anyway...
This PR fixes the aforementioned crash, by reverting back to `instanceof` if it's on web. 🥴