### PR TITLE
Normalize vibration for Joy-Cons

### DIFF
--- a/scripts/__input_class_gamepad/__input_class_gamepad.gml
+++ b/scripts/__input_class_gamepad/__input_class_gamepad.gml
@@ -29,6 +29,7 @@ function __input_class_gamepad(_index) constructor
     __steam_handle       = undefined;
     
     __vibration_support = false;
+    __vibration_scale   = 1;
     __vibration_left    = 0;
     __vibration_right   = 0;
     __vibration_received_this_frame = false;
@@ -81,6 +82,10 @@ function __input_class_gamepad(_index) constructor
             if (os_type == os_ps5)
             {
                 ps5_gamepad_set_vibration_mode(index, ps5_gamepad_vibration_mode_compatible);
+            }            
+            else if (((os_type == os_windows) || (os_type == os_switch)) && __input_string_contains(raw_type, "JoyCon", "SwitchHandheld"))
+            {
+                __vibration_scale = INPUT_VIBRATION_JOYCON_STRENGTH;
             }
         
             gamepad_set_vibration(index, 0, 0);
@@ -272,25 +277,25 @@ function __input_class_gamepad(_index) constructor
         {
             if (__vibration_received_this_frame && input_window_has_focus())
             {
+                var _vibration_low  = __vibration_scale * __vibration_left;
+                var _vibration_high = __vibration_scale * __vibration_right;
+                
                 if (os_type == os_switch)
                 {
-                    var _lowStrength  = INPUT_VIBRATION_SWITCH_OS_STRENGTH*__vibration_left;
-                    var _highStrength = INPUT_VIBRATION_SWITCH_OS_STRENGTH*__vibration_right;
-                    
                     if ((raw_type == "SwitchJoyConLeft") || (raw_type == "SwitchJoyConRight"))
                     {
                         //Documentation said to use switch_controller_motor_single for these two controller types but I'll be damned if I can feel any difference!
-                        switch_controller_vibrate_hd(index, switch_controller_motor_single, _highStrength, 250, _lowStrength, 160);
+                        switch_controller_vibrate_hd(index, switch_controller_motor_single, _vibration_high, 250, _vibration_low, 160);
                     }
                     else
                     {
-                        switch_controller_vibrate_hd(index, switch_controller_motor_left,  _highStrength, 250, _lowStrength, 160);
-                        switch_controller_vibrate_hd(index, switch_controller_motor_right, _highStrength, 250, _lowStrength, 160);
+                        switch_controller_vibrate_hd(index, switch_controller_motor_left,  _vibration_high, 250, _vibration_low, 160);
+                        switch_controller_vibrate_hd(index, switch_controller_motor_right, _vibration_high, 250, _vibration_low, 160);
                     }
                 }
                 else
                 {
-                    gamepad_set_vibration(index, __vibration_left, __vibration_right);
+                    gamepad_set_vibration(index, _vibration_low, _vibration_high);
                 }
             }
             else

--- a/scripts/__input_config_vibration/__input_config_vibration.gml
+++ b/scripts/__input_config_vibration/__input_config_vibration.gml
@@ -12,10 +12,9 @@
 //The default vibration strength. This value can be changed later by using input_vibrate_set_strength()
 #macro INPUT_VIBRATION_DEFAULT_STRENGTH  1.0
 
-//Switch's vibration motors can be a bit, uh, intense
-//This value allows you to reduce the strength of vibration relative to other platforms
-//Please note that this is only applied specifically when playing on a Switch console and won't automatically be applied on other OSes
-#macro INPUT_VIBRATION_SWITCH_OS_STRENGTH  0.4
+//Joy-Con vibration motors can be a bit, uh, intense
+//This value allows you to reduce the strength of vibration relative to other devices
+#macro INPUT_VIBRATION_JOYCON_STRENGTH  0.4
 
 //The default haptic trigger effect strength. This value can be changed later by using input_trigger_effect_set_strength()
 #macro INPUT_TRIGGER_EFFECT_DEFAULT_STRENGTH  1.0

--- a/scripts/__input_validate_macros/__input_validate_macros.gml
+++ b/scripts/__input_validate_macros/__input_validate_macros.gml
@@ -431,9 +431,9 @@ function __input_validate_macros()
         __input_error("INPUT_VIBRATION_DEFAULT_STRENGTH must be a number between 0.0 and 1.0 (inclusive)");
     }
     
-    if (!is_numeric(INPUT_VIBRATION_SWITCH_OS_STRENGTH) || (INPUT_VIBRATION_SWITCH_OS_STRENGTH < 0) || (INPUT_VIBRATION_SWITCH_OS_STRENGTH > 1.0))
+    if (!is_numeric(INPUT_VIBRATION_JOYCON_STRENGTH) || (INPUT_VIBRATION_JOYCON_STRENGTH < 0) || (INPUT_VIBRATION_JOYCON_STRENGTH > 1.0))
     {
-        __input_error("INPUT_VIBRATION_SWITCH_OS_STRENGTH must be a number between 0.0 and 1.0 (inclusive)");
+        __input_error("INPUT_VIBRATION_JOYCON_STRENGTH must be a number between 0.0 and 1.0 (inclusive)");
     }
     
     if (!is_numeric(INPUT_TRIGGER_EFFECT_DEFAULT_STRENGTH) || (INPUT_TRIGGER_EFFECT_DEFAULT_STRENGTH < 0) || (INPUT_TRIGGER_EFFECT_DEFAULT_STRENGTH > 1.0))


### PR DESCRIPTION
Adds vibration damping for Joy-Cons on Steam, exempts Switch Pro gamepads from damping on Switch