### PR TITLE
Fixes cursor error (6.0)

### DIFF
--- a/scripts/__input_initialize/__input_initialize.gml
+++ b/scripts/__input_initialize/__input_initialize.gml
@@ -18,7 +18,7 @@ function __input_initialize()
     
     __input_trace("Welcome to Input by @jujuadams and @offalynne! This is version ", __INPUT_VERSION, ", ", __INPUT_DATE);
     
-    _global.__use_is_instanceof = (string_copy(GM_runtime_version, 1, 4) == "2023");
+    _global.__use_is_instanceof = (!__INPUT_ON_WEB) && (string_copy(GM_runtime_version, 1, 4) == "2023");
     if (_global.__use_is_instanceof) __input_trace("On runtime ", GM_runtime_version, ", using is_instanceof()");
     
     //Set up a time source to manage input_controller_object

--- a/scripts/input_cursor_previous_x/input_cursor_previous_x.gml
+++ b/scripts/input_cursor_previous_x/input_cursor_previous_x.gml
@@ -7,7 +7,7 @@
 /// @param   [playerIndex=0]
 /// @param   [coordSpace]     Coordinate space to use. If not specified, the coordinate space set by input_cursor_coord_space_set() is used
 
-function input_cursor_previous_x(_player_index = 0, _outputSystem = _global.__pointer_coord_space)
+function input_cursor_previous_x(_player_index = 0, _outputSystem = undefined)
 {
     __INPUT_GLOBAL_STATIC_LOCAL  //Set static _global
     __INPUT_VERIFY_PLAYER_INDEX
@@ -16,5 +16,5 @@ function input_cursor_previous_x(_player_index = 0, _outputSystem = _global.__po
     return __input_transform_coordinate(_cursor.__prev_x,
                                         _cursor.__prev_y,
                                         _cursor.__coord_space,
-                                        _outputSystem).x;
+                                        _outputSystem ?? _global.__pointer_coord_space).x;
 }

--- a/scripts/input_cursor_previous_y/input_cursor_previous_y.gml
+++ b/scripts/input_cursor_previous_y/input_cursor_previous_y.gml
@@ -7,7 +7,7 @@
 /// @param   [playerIndex=0]
 /// @param   [coordSpace]     Coordinate space to use. If not specified, the coordinate space set by input_cursor_coord_space_set() is used
 
-function input_cursor_previous_y(_player_index = 0, _outputSystem = _global.__pointer_coord_space)
+function input_cursor_previous_y(_player_index = 0, _outputSystem = undefined)
 {
     __INPUT_GLOBAL_STATIC_LOCAL  //Set static _global
     __INPUT_VERIFY_PLAYER_INDEX
@@ -16,5 +16,5 @@ function input_cursor_previous_y(_player_index = 0, _outputSystem = _global.__po
     return __input_transform_coordinate(_cursor.__prev_x,
                                         _cursor.__prev_y,
                                         _cursor.__coord_space,
-                                        _outputSystem).y;
+                                        _output_system ?? _global.__pointer_coord_space).y;
 }

--- a/scripts/input_cursor_x/input_cursor_x.gml
+++ b/scripts/input_cursor_x/input_cursor_x.gml
@@ -12,11 +12,9 @@ function input_cursor_x(_player_index = 0, _output_system = undefined)
     __INPUT_GLOBAL_STATIC_LOCAL  //Set static _global
     __INPUT_VERIFY_PLAYER_INDEX
     
-    if (_output_system == undefined) _output_system = _global.__pointer_coord_space;
-    
     var _cursor = _global.__players[_player_index].__cursor;
     return __input_transform_coordinate(_cursor.__x,
                                         _cursor.__y,
                                         _cursor.__coord_space,
-                                        _output_system).x;
+                                        _output_system ?? _global.__pointer_coord_space).x;
 }

--- a/scripts/input_cursor_y/input_cursor_y.gml
+++ b/scripts/input_cursor_y/input_cursor_y.gml
@@ -12,11 +12,9 @@ function input_cursor_y(_player_index = 0, _output_system = undefined)
     __INPUT_GLOBAL_STATIC_LOCAL  //Set static _global
     __INPUT_VERIFY_PLAYER_INDEX
     
-    if (_output_system == undefined) _output_system = _global.__pointer_coord_space;
-    
     var _cursor = _global.__players[_player_index].__cursor;
     return __input_transform_coordinate(_cursor.__x,
                                         _cursor.__y,
                                         _cursor.__coord_space,
-                                        _output_system).y;
+                                        _output_system ?? _global.__pointer_coord_space).y;
 }

--- a/scripts/input_mouse_dx/input_mouse_dx.gml
+++ b/scripts/input_mouse_dx/input_mouse_dx.gml
@@ -6,8 +6,8 @@
 /// 
 /// @param [coordSpace]  Coordinate space to use. If not specified, the coordinate space set by input_mouse_coord_space_set() is used
 
-function input_mouse_dx(_coord_space = _global.__pointer_coord_space)
+function input_mouse_dx(_coord_space = undefined)
 {
     __INPUT_GLOBAL_STATIC_LOCAL  //Set static _global
-    return _global.__pointer_dx[_coord_space];
+    return _global.__pointer_dx[_coord_space ?? _global.__pointer_coord_space];
 }

--- a/scripts/input_mouse_dy/input_mouse_dy.gml
+++ b/scripts/input_mouse_dy/input_mouse_dy.gml
@@ -6,8 +6,8 @@
 /// 
 /// @param [coordSpace]  Coordinate space to use. If not specified, the coordinate space set by input_mouse_coord_space_set() is used
 
-function input_mouse_dy(_coord_space = _global.__pointer_coord_space)
+function input_mouse_dy(_coord_space = undefined)
 {
     __INPUT_GLOBAL_STATIC_LOCAL  //Set static _global
-    return _global.__pointer_dy[_coord_space];
+    return _global.__pointer_dy[_coord_space ?? _global.__pointer_coord_space];
 }

--- a/scripts/input_mouse_x/input_mouse_x.gml
+++ b/scripts/input_mouse_x/input_mouse_x.gml
@@ -6,8 +6,8 @@
 /// 
 /// @param [coordSpace]  Coordinate space to use. If not specified, the coordinate space set by input_mouse_coord_space_set() is used
 
-function input_mouse_x(_coord_space = _global.__pointer_coord_space)
+function input_mouse_x(_coord_space = undefined)
 {
     __INPUT_GLOBAL_STATIC_LOCAL  //Set static _global
-    return _global.__pointer_x[_coord_space];
+    return _global.__pointer_x[_coord_space ?? _global.__pointer_coord_space];
 }

--- a/scripts/input_mouse_y/input_mouse_y.gml
+++ b/scripts/input_mouse_y/input_mouse_y.gml
@@ -6,8 +6,8 @@
 /// 
 /// @param [coordSpace]  Coordinate space to use. If not specified, the coordinate space set by input_mouse_coord_space_set() is used
 
-function input_mouse_y(_coord_space = _global.__pointer_coord_space)
+function input_mouse_y(_coord_space = undefined)
 {
     __INPUT_GLOBAL_STATIC_LOCAL  //Set static _global
-    return _global.__pointer_y[_coord_space];
+    return _global.__pointer_y[_coord_space ?? _global.__pointer_coord_space];
 }


### PR DESCRIPTION
This PR also includes fixes for 2023 not running on HTML5 (as per #629).
This also cleans up and uniforms the `undefined` checks, as seen with `input_cursor_x` and `input_cursor_y`. (Using nullish operator)