### PR TITLE
Gamepad LED pattern getter

### DIFF
--- a/input.yyp
+++ b/input.yyp
@@ -104,6 +104,7 @@
     {"id":{"name":"input_profile_get_array","path":"scripts/input_profile_get_array/input_profile_get_array.yy",},"order":3,},
     {"id":{"name":"input_cursor_previous_x","path":"scripts/input_cursor_previous_x/input_cursor_previous_x.yy",},"order":2,},
     {"id":{"name":"input_gyro_params_set","path":"scripts/input_gyro_params_set/input_gyro_params_set.yy",},"order":3,},
+    {"id":{"name":"input_led_pattern_get","path":"scripts/input_led_pattern_get/input_led_pattern_get.yy",},"order":14,},
     {"id":{"name":"obj_example_drop_in_gameplay","path":"objects/obj_example_drop_in_gameplay/obj_example_drop_in_gameplay.yy",},"order":0,},
     {"id":{"name":"input_check_pressed","path":"scripts/input_check_pressed/input_check_pressed.yy",},"order":1,},
     {"id":{"name":"input_icon_not_a_binding","path":"scripts/input_icon_not_a_binding/input_icon_not_a_binding.yy",},"order":8,},
@@ -377,6 +378,7 @@
     "children": [],
   },
   "RoomOrderNodes": [
+    {"roomId":{"name":"rm_test","path":"rooms/rm_test/rm_test.yy",},},
     {"roomId":{"name":"rm_example_platformer","path":"rooms/rm_example_platformer/rm_example_platformer.yy",},},
     {"roomId":{"name":"rm_example_drop_in_gameplay","path":"rooms/rm_example_drop_in_gameplay/rm_example_drop_in_gameplay.yy",},},
     {"roomId":{"name":"rm_example_tds","path":"rooms/rm_example_tds/rm_example_tds.yy",},},
@@ -384,9 +386,7 @@
     {"roomId":{"name":"rm_example_mp_join","path":"rooms/rm_example_mp_join/rm_example_mp_join.yy",},},
     {"roomId":{"name":"rm_example_mp_gameplay","path":"rooms/rm_example_mp_gameplay/rm_example_mp_gameplay.yy",},},
     {"roomId":{"name":"rm_example_rebinding","path":"rooms/rm_example_rebinding/rm_example_rebinding.yy",},},
-    {"roomId":{"name":"rm_test","path":"rooms/rm_test/rm_test.yy",},},
     {"roomId":{"name":"rm_test_coord_spaces","path":"rooms/rm_test_coord_spaces/rm_test_coord_spaces.yy",},},
-    {"roomId":{"name":"rm_test","path":"rooms/rm_test/rm_test.yy",},},
   ],
   "Folders": [
     {"resourceType":"GMFolder","resourceVersion":"1.0","name":"Examples","folderPath":"folders/Examples.yy","order":1,},

--- a/objects/obj_gamepad_tester/Draw_0.gml
+++ b/objects/obj_gamepad_tester/Draw_0.gml
@@ -102,6 +102,7 @@ _string += "Player gamepad: " + string(input_player_get_gamepad()) + "\n\n";
 _string += "GUID = \"" + gamepad_get_guid(input_player_get_gamepad()) + "\"\n";
 _string += "Input gamepad desc = \"" + input_gamepad_get_description(input_player_get_gamepad()) + "\"\n";
 _string += "Input gamepad type = \"" + input_gamepad_get_type(input_player_get_gamepad()) + "\"\n";
+_string += "Input gamepad LED  = \"" + string(input_led_pattern_get()) + "\"\n";
 _string += "\n";
 
 _string += "Left          = " + string(input_value("left"  )) + "    " + input_verb_get_icon("left"  ) + "\n";

--- a/scripts/__input_initialize/__input_initialize.gml
+++ b/scripts/__input_initialize/__input_initialize.gml
@@ -439,6 +439,40 @@ function __input_initialize()
     }
     
     #endregion
+    
+    
+    #region
+    
+    //Gamepad LED patterns by device type
+    _global.__gamepad_led_pattern_dict = {
+
+        INPUT_GAMEPAD_TYPE_PS5: [
+            [false, false, true,  false, false],  //P1: --X--
+            [false, true,  false, true,  false],  //P2: -X-X-
+            [true,  false, true,  false, true ],  //P3: X-X-X
+            [true,  true,  false, true,  true ],  //P4: XX-XX
+        ],
+        
+        INPUT_GAMEPAD_TYPE_SWITCH: [
+            [true,  false, false, false],         //P1: X---
+            [true,  true,  false, false],         //P2: XX--
+            [true,  true,  true,  false],         //P3: XXX-
+            [true,  true,  true,  true ],         //P4: XXXX
+            [true,  false, false, true ],         //P5: X--X
+            [true,  false, true,  false],         //P6: X-X-
+            [true,  false, true,  true ],         //P7: X-XX
+            [false, true,  true,  false],         //P8: -XX-
+        ],
+        
+        INPUT_GAMEPAD_TYPE_XBOX_360: [
+            [true,  false, false, false],         //P1: X---
+            [false, true,  false, false],         //P2: -X--
+            [false, false, true,  false],         //P3: --X-
+            [false, false, false, true ],         //P4: ---X
+        ],
+    }
+    
+    #endregion
 
 
 

--- a/scripts/__input_macros/__input_macros.gml
+++ b/scripts/__input_macros/__input_macros.gml
@@ -77,11 +77,17 @@
 #macro __INPUT_KEYBOARD_SUPPORT           (__INPUT_KEYBOARD_NORMATIVE || (os_type == os_android))
 #macro __INPUT_GAMEPAD_VIBRATION_SUPPORT  (__INPUT_ON_CONSOLE || (!__INPUT_ON_WEB && (os_type == os_windows)))
 #macro __INPUT_SDL2_SUPPORT               (!__INPUT_ON_WEB && (__INPUT_ON_DESKTOP || (os_type == os_android)))
+#macro __INPUT_LED_PATTERN_SUPPORT        ((os_type == os_ps5) || (os_type == os_switch) || (os_type == os_tvos) || (os_type == os_ios) || ((os_type == os_windows) && !__INPUT_ON_WEB))
 
 #macro __INPUT_HOLD_THRESHOLD           0.2  //Minimum value from an axis for that axis to be considered activated at the gamepad layer. This is *not* the same as min/max thresholds for players
 #macro __INPUT_DELTA_HOTSWAP_THRESHOLD  0.1  //Minimum (absolute) change in gamepad mapping value between frames to register as new input. This triggers hotswapping
 
 #macro __INPUT_RATE_LIMIT_DURATION  500 //In milliseconds
+
+//Gamepad LED layout types
+#macro __INPUT_LED_LAYOUT_HORIZONTAL  "horizontal"
+#macro __INPUT_LED_LAYOUT_VERTICAL    "vertical"
+#macro __INPUT_LED_LAYOUT_RADIAL      "radial"
 
 //Valid keycode bounds
 #macro __INPUT_KEYCODE_MIN 8

--- a/scripts/__input_system_tick/__input_system_tick.gml
+++ b/scripts/__input_system_tick/__input_system_tick.gml
@@ -430,7 +430,11 @@ function __input_system_tick()
                     {
                         if (_steam_handles_changed) 
                         {
-                            _gamepad.virtual_set();
+                            with (_gamepad)
+                            {
+                                virtual_set();
+                                led_pattern_set();
+                            }
                         }
                         
                         _gamepad.tick();

--- a/scripts/input_led_pattern_get/input_led_pattern_get.gml
+++ b/scripts/input_led_pattern_get/input_led_pattern_get.gml
@@ -1,0 +1,19 @@
+/// @desc    Returns the player device color
+/// @param   [playerIndex=0]
+/// @param   [binding=undefined]
+
+function input_led_pattern_get(_player_index = 0, _binding = undefined)
+{
+    __INPUT_GLOBAL_STATIC_LOCAL  //Set static _global
+    
+    var _gamepad = input_player_get_gamepad(_player_index, _binding);
+    if (_gamepad >= 0)
+    {
+        with _global.__gamepads[@ _gamepad]
+        {
+            return __led_pattern;
+        }
+    }
+    
+    return undefined;
+}

--- a/scripts/input_led_pattern_get/input_led_pattern_get.yy
+++ b/scripts/input_led_pattern_get/input_led_pattern_get.yy
@@ -1,0 +1,11 @@
+{
+  "resourceType": "GMScript",
+  "resourceVersion": "1.0",
+  "name": "input_led_pattern_get",
+  "isDnD": false,
+  "isCompatibility": false,
+  "parent": {
+    "name": "Other",
+    "path": "folders/Input/Other.yy",
+  },
+}


### PR DESCRIPTION
_docs entry draft for ease of PR review:_

## `input_led_pattern_get([playerIndex], [binding])`

*Returns:* Struct, detailing the state of a player gamepad LED pattern (or `undefined` if none exist)

|Name           |Datatype                     |Purpose                                                                                                                                                                                                    |
|---------------|-----------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
|`[playerIndex]`|integer                      |Player to target. If not specified, player 0 is used                                                                                                                                                       |
|`[binding]`    |[binding](Verbs-and-Bindings)|Binding to return the gamepad LED pattern for. This is only valid in [multidevice mode](Input-Sources?id=input_source_modemultidevice). If no binding is provided then LED pattern for the player's first connected gamepad is returned|. Gamepad LED patterns are available on [Switch](https://www.nintendo.com/my/support/qa/detail/33822), [PlayStation 5](https://www.4gamer.net/games/990/G999027/20201002016), iOS, and tvOS platforms, as well as Steam on Windows, which additionally supports [Xbox 360](https://support.xbox.com/en-CA/help/xbox-360/accessories/controllers) devices.


This function returns a struct that describes the state of a player's gamepad LED pattern, following the formatting below. This data is useful for matching onscreen indicators with the real world device in-hand in hotswap and multiplayer contexts, such as an input source assignment screen.

If the player has no connected gamepad then this function will return `undefined`. If you provide a [binding](Verbs-and-Bindings) to check, and Input is running in [multidevice mode](Input-Sources?id=input_source_modemultidevice), then this function will return the LED pattern for the specific gamepad associated with the provided binding.

?> If the player has multiple gamepad [sources](Input-Sources) assigned to them, and no binding is provided, then this function will return the LED pattern for the first connected gamepad.

!> Do not edit the struct that this function returns! You may encounter undefined behaviour if you do.

```
{
    value:   <number indicated by the LED pattern>,
    pattern: <array of boolean values indicating individual LED component states>,
    layout:  <string that indicates the LED pattern's layout arrangement>,
}
```
Possible string values for the struct variable `layout` are listed below

|Value         | Relevant gamepad types | Indication                          |
|--------------|------------------------|-------------------------------------|
| `horizontal` | PS5, MFi, Switch       | LED pattern layout is left to right |
| `vertical`   | Switch                 | LED pattern layout is top to bottom |
| `radial`     | Xbox 360               | LED pattern layout is circle quadrants in Z-order (top left, top right, bottom left, bottom right)|
