### PR TITLE
Gamepad LED pattern getter

### DIFF
--- a/input.yyp
+++ b/input.yyp
@@ -104,6 +104,7 @@
     {"id":{"name":"input_profile_get_array","path":"scripts/input_profile_get_array/input_profile_get_array.yy",},"order":3,},
     {"id":{"name":"input_cursor_previous_x","path":"scripts/input_cursor_previous_x/input_cursor_previous_x.yy",},"order":2,},
     {"id":{"name":"input_gyro_params_set","path":"scripts/input_gyro_params_set/input_gyro_params_set.yy",},"order":3,},
+    {"id":{"name":"input_led_pattern_get","path":"scripts/input_led_pattern_get/input_led_pattern_get.yy",},"order":14,},
     {"id":{"name":"obj_example_drop_in_gameplay","path":"objects/obj_example_drop_in_gameplay/obj_example_drop_in_gameplay.yy",},"order":0,},
     {"id":{"name":"input_check_pressed","path":"scripts/input_check_pressed/input_check_pressed.yy",},"order":1,},
     {"id":{"name":"input_icon_not_a_binding","path":"scripts/input_icon_not_a_binding/input_icon_not_a_binding.yy",},"order":8,},
@@ -377,6 +378,7 @@
     "children": [],
   },
   "RoomOrderNodes": [
+    {"roomId":{"name":"rm_test","path":"rooms/rm_test/rm_test.yy",},},
     {"roomId":{"name":"rm_example_platformer","path":"rooms/rm_example_platformer/rm_example_platformer.yy",},},
     {"roomId":{"name":"rm_example_drop_in_gameplay","path":"rooms/rm_example_drop_in_gameplay/rm_example_drop_in_gameplay.yy",},},
     {"roomId":{"name":"rm_example_tds","path":"rooms/rm_example_tds/rm_example_tds.yy",},},
@@ -384,9 +386,7 @@
     {"roomId":{"name":"rm_example_mp_join","path":"rooms/rm_example_mp_join/rm_example_mp_join.yy",},},
     {"roomId":{"name":"rm_example_mp_gameplay","path":"rooms/rm_example_mp_gameplay/rm_example_mp_gameplay.yy",},},
     {"roomId":{"name":"rm_example_rebinding","path":"rooms/rm_example_rebinding/rm_example_rebinding.yy",},},
-    {"roomId":{"name":"rm_test","path":"rooms/rm_test/rm_test.yy",},},
     {"roomId":{"name":"rm_test_coord_spaces","path":"rooms/rm_test_coord_spaces/rm_test_coord_spaces.yy",},},
-    {"roomId":{"name":"rm_test","path":"rooms/rm_test/rm_test.yy",},},
   ],
   "Folders": [
     {"resourceType":"GMFolder","resourceVersion":"1.0","name":"Examples","folderPath":"folders/Examples.yy","order":1,},

--- a/objects/obj_gamepad_tester/Draw_0.gml
+++ b/objects/obj_gamepad_tester/Draw_0.gml
@@ -102,6 +102,7 @@ _string += "Player gamepad: " + string(input_player_get_gamepad()) + "\n\n";
 _string += "GUID = \"" + gamepad_get_guid(input_player_get_gamepad()) + "\"\n";
 _string += "Input gamepad desc = \"" + input_gamepad_get_description(input_player_get_gamepad()) + "\"\n";
 _string += "Input gamepad type = \"" + input_gamepad_get_type(input_player_get_gamepad()) + "\"\n";
+_string += "Input gamepad LED  = " + string(input_led_pattern_get(input_player_get_gamepad())) + "\n";
 _string += "\n";
 
 _string += "Left          = " + string(input_value("left"  )) + "    " + input_verb_get_icon("left"  ) + "\n";

--- a/scripts/__input_class_gamepad/__input_class_gamepad.gml
+++ b/scripts/__input_class_gamepad/__input_class_gamepad.gml
@@ -71,9 +71,10 @@ function __input_class_gamepad(_index) constructor
         __input_gamepad_find_in_sdl2_database();
         __input_gamepad_set_type();
         __input_gamepad_set_blacklist();
-        __input_gamepad_set_mapping();       
+        __input_gamepad_set_mapping();
         
         virtual_set();
+        led_set();
         
         __vibration_support = __global.__vibration_allowed_on_platform && ((os_type != os_windows) || xinput);        
         if (__vibration_support)
@@ -352,6 +353,47 @@ function __input_class_gamepad(_index) constructor
             description = _description;
             raw_type    = _raw_type;
             simple_type = _simple_type;
+        }
+    }
+    
+    static led_set = function()
+    {
+        __led_offset = 0;
+        __led_layout = "unknown";
+        __led_type   = INPUT_GAMEPAD_TYPE_XBOX_360;
+        
+        //Platform is unsupported, or lacks Steam Input handle
+        if (!__INPUT_LED_PATTERN_SUPPORT || ((os_type == os_windows) && (!is_numeric(__steam_handle)))) return;
+        
+        //Handle whether gamepad index 0 is used or reserved
+        if (!__INPUT_ON_WEB && ((os_type == os_ios) || (os_type == os_tvos) || (os_type == os_switch)))
+        { 
+            if (index == 0) return;
+            __led_offset = -1;
+        }
+        
+        //MFi gamepad case
+        if ((raw_type == "AppleController") && ((os_type == os_tvos) || (os_type == os_ios)))
+        {
+            __led_layout = "horizontal";
+            return;
+        }
+        
+        switch(simple_type)
+        {
+            case INPUT_GAMEPAD_TYPE_PS5:
+                __led_layout = "horizontal"; 
+                __led_type   = INPUT_GAMEPAD_TYPE_PS5;
+            break;
+            case INPUT_GAMEPAD_TYPE_SWITCH:
+            case INPUT_GAMEPAD_TYPE_JOYCON_LEFT:
+            case INPUT_GAMEPAD_TYPE_JOYCON_RIGHT:
+                __led_layout = ((raw_type == "SwitchJoyConPair") || (!INPUT_SWITCH_HORIZONTAL_HOLDTYPE && (simple_type != INPUT_GAMEPAD_TYPE_SWITCH))? "vertical" : "horizontal");
+                if (is_numeric(__steam_handle)) __led_type = INPUT_GAMEPAD_TYPE_SWITCH; //Steam falls back to the Xbox 360 pattern with Switch layout
+            break;            
+            case INPUT_GAMEPAD_TYPE_XBOX_360:
+                __led_layout = "radial";
+            break;
         }
     }
     

--- a/scripts/__input_initialize/__input_initialize.gml
+++ b/scripts/__input_initialize/__input_initialize.gml
@@ -439,6 +439,37 @@ function __input_initialize()
     }
     
     #endregion
+    
+    
+    #region
+    
+    //Gamepad LED patterns by device type
+    _global.__gamepad_led_pattern_dict = {
+        INPUT_GAMEPAD_TYPE_PS5: [                 //PS5
+            [false, false, true,  false, false],  //P1: --X--
+            [false, true,  false, true,  false],  //P2: -X-X-
+            [true,  false, true,  false, true ],  //P3: X-X-X
+            [true,  true,  false, true,  true ],  //P4: XX-XX
+        ],        
+        INPUT_GAMEPAD_TYPE_SWITCH: [              //Switch
+            [true,  false, false, false],         //P1: X---
+            [true,  true,  false, false],         //P2: XX--
+            [true,  true,  true,  false],         //P3: XXX-
+            [true,  true,  true,  true ],         //P4: XXXX
+            [true,  false, false, true ],         //P5: X--X
+            [true,  false, true,  false],         //P6: X-X-
+            [true,  false, true,  true ],         //P7: X-XX
+            [false, true,  true,  false],         //P8: -XX-
+        ],        
+        INPUT_GAMEPAD_TYPE_XBOX_360: [            //Xbox 360
+            [true,  false, false, false],         //P1: X---
+            [false, true,  false, false],         //P2: -X--
+            [false, false, true,  false],         //P3: --X-
+            [false, false, false, true ],         //P4: ---X
+        ],
+    }
+    
+    #endregion
 
 
 

--- a/scripts/__input_macros/__input_macros.gml
+++ b/scripts/__input_macros/__input_macros.gml
@@ -77,6 +77,7 @@
 #macro __INPUT_KEYBOARD_SUPPORT           (__INPUT_KEYBOARD_NORMATIVE || (os_type == os_android))
 #macro __INPUT_GAMEPAD_VIBRATION_SUPPORT  (__INPUT_ON_CONSOLE || (!__INPUT_ON_WEB && (os_type == os_windows)))
 #macro __INPUT_SDL2_SUPPORT               (!__INPUT_ON_WEB && (__INPUT_ON_DESKTOP || (os_type == os_android)))
+#macro __INPUT_LED_PATTERN_SUPPORT        ((os_type == os_ps5) || (os_type == os_switch) || (os_type == os_tvos) || (os_type == os_ios) || ((os_type == os_windows) && !__INPUT_ON_WEB))
 
 #macro __INPUT_HOLD_THRESHOLD           0.2  //Minimum value from an axis for that axis to be considered activated at the gamepad layer. This is *not* the same as min/max thresholds for players
 #macro __INPUT_DELTA_HOTSWAP_THRESHOLD  0.1  //Minimum (absolute) change in gamepad mapping value between frames to register as new input. This triggers hotswapping

--- a/scripts/__input_system_tick/__input_system_tick.gml
+++ b/scripts/__input_system_tick/__input_system_tick.gml
@@ -430,7 +430,11 @@ function __input_system_tick()
                     {
                         if (_steam_handles_changed) 
                         {
-                            _gamepad.virtual_set();
+                            with (_gamepad)
+                            {
+                                virtual_set();
+                                led_set();
+                            }
                         }
                         
                         _gamepad.tick();

--- a/scripts/input_led_pattern_get/input_led_pattern_get.gml
+++ b/scripts/input_led_pattern_get/input_led_pattern_get.gml
@@ -24,5 +24,5 @@ function input_led_pattern_get(_index)
         return _led_pattern_unknown;
     }
     
-    return _gamepad._led_pattern;
+    return _gamepad.__led_pattern;
 }

--- a/scripts/input_led_pattern_get/input_led_pattern_get.gml
+++ b/scripts/input_led_pattern_get/input_led_pattern_get.gml
@@ -21,7 +21,10 @@ function input_led_pattern_get(_index)
     }
 
     var _gamepad = _global.__gamepads[@ _index];
-    if (!is_struct(_gamepad) || (_gamepad.__led_layout == "unknown")) return _led_pattern;
+    if (!is_struct(_gamepad) || (_gamepad.__led_layout == "unknown"))
+    {
+        return _led_pattern;
+    }
 
     with (_led_pattern)
     {

--- a/scripts/input_led_pattern_get/input_led_pattern_get.gml
+++ b/scripts/input_led_pattern_get/input_led_pattern_get.gml
@@ -5,33 +5,24 @@ function input_led_pattern_get(_index)
 {
     __INPUT_GLOBAL_STATIC_LOCAL  //Set static _global
 
-    static _led_pattern = {};
-    with (_led_pattern)
-    {
-        value   = 0;
-        pattern = [];
-        layout  = "unknown";
+    static _led_pattern_unknown = {
+        value:   0,
+        pattern: [],
+        layout:  "unknown",
     }
     
     if ((_index == undefined)
     ||  (_index < 0)
     ||  (_index >= array_length(_global.__gamepads)))
     {
-        return _led_pattern;
+        return _led_pattern_unknown;
     }
 
     var _gamepad = _global.__gamepads[@ _index];
     if (!is_struct(_gamepad) || (_gamepad.__led_layout == "unknown"))
     {
-        return _led_pattern;
-    }
-
-    with (_led_pattern)
-    {
-        value   = _gamepad.index + _gamepad.__led_offset + 1;
-        pattern = _global.__gamepad_led_pattern_dict[$ _gamepad.__led_type][@ _gamepad.index + _gamepad.__led_offset];
-        layout  = _gamepad.__led_layout;
+        return _led_pattern_unknown;
     }
     
-    return _led_pattern;
+    return _gamepad._led_pattern;
 }

--- a/scripts/input_led_pattern_get/input_led_pattern_get.gml
+++ b/scripts/input_led_pattern_get/input_led_pattern_get.gml
@@ -1,0 +1,34 @@
+/// @desc    Returns the player gamepad LED pattern
+/// @param   gamepadIndex
+
+function input_led_pattern_get(_index)
+{
+    __INPUT_GLOBAL_STATIC_LOCAL  //Set static _global
+
+    static _led_pattern = {};
+    with (_led_pattern)
+    {
+        value   = 0;
+        pattern = [];
+        layout  = "unknown";
+    }
+    
+    if ((_index == undefined)
+    ||  (_index < 0)
+    ||  (_index >= array_length(_global.__gamepads)))
+    {
+        return _led_pattern;
+    }
+
+    var _gamepad = _global.__gamepads[@ _index];
+    if (!is_struct(_gamepad) || (_gamepad.__led_layout == "unknown")) return _led_pattern;
+
+    with (_led_pattern)
+    {
+        value   = _gamepad.index + _gamepad.__led_offset + 1;
+        pattern = _global.__gamepad_led_pattern_dict[$ _gamepad.__led_type][@ _gamepad.index + _gamepad.__led_offset];
+        layout  = _gamepad.__led_layout;
+    }
+    
+    return _led_pattern;
+}

--- a/scripts/input_led_pattern_get/input_led_pattern_get.yy
+++ b/scripts/input_led_pattern_get/input_led_pattern_get.yy
@@ -1,0 +1,11 @@
+{
+  "resourceType": "GMScript",
+  "resourceVersion": "1.0",
+  "name": "input_led_pattern_get",
+  "isDnD": false,
+  "isCompatibility": false,
+  "parent": {
+    "name": "Other",
+    "path": "folders/Input/Other.yy",
+  },
+}


### PR DESCRIPTION
_docs entry draft for ease of PR review:_

## `input_led_pattern_get(gamepadIndex)`

*Returns:* Struct, detailing the state of a player gamepad LED pattern

|Name          |Datatype|Purpose                                               |
|--------------|--------|------------------------------------------------------|
|`gamepadIndex`|integer |Index of the gamepad to target, using GameMaker's native [gamepad indexes](https://manual.yoyogames.com/#t=GameMaker_Language%2FGML_Reference%2FGame_Input%2FGamePad_Input%2FGamepad_Input.htm)|

This function returns a struct that describes the state of a gamepad's LED pattern, following the formatting below. This data is useful for matching onscreen indicators with the real world device in-hand in hotswap and multiplayer contexts, such as a player join screen.

Gamepad LED patterns are available on [Switch](https://www.nintendo.com/my/support/qa/detail/33822), [PlayStation 5](https://www.4gamer.net/games/990/G999027/20201002016), iOS, and tvOS platforms, as well as [Steam](Steamworks) on Windows, which additionally supports [Xbox 360](https://support.xbox.com/en-CA/help/xbox-360/accessories/controllers) type gamepads.

!> Do not edit the struct that this function returns! You may encounter undefined behaviour if you do.

```
{
    value:   <number indicated by the LED pattern, 0 if none>,
    pattern: <variable size array of boolean values indicating state per LED (on <true>, or off <false>)>,
    layout:  <string that indicates the LED pattern's layout arrangement>,
}
```
Possible string values for the struct variable `layout` are listed below

|Value         | Gamepad types          | Indicated LED layout       |
|--------------|------------------------|----------------------------|
| `horizontal` | PS5, MFi, Switch       | In a row, left to right    |
| `vertical`   | Switch                 | In a column, top to bottom |
| `radial`     | Xbox 360               | Circle quadrants in left-to-right order (top left, right, bottom left, right)|
| `unknown`    | All                    | Feature unsupported for platform or gamepad type |
