### PR TITLE
Publicize general platform Macros

### DIFF
--- a/objects/obj_gamepad_tester/Step_1.gml
+++ b/objects/obj_gamepad_tester/Step_1.gml
@@ -2,7 +2,7 @@ var _size = gamepad_get_device_count();
 var _delta = (input_keyboard_check_pressed(vk_down) - input_keyboard_check_pressed(vk_up));
 
 var _first_gamepad = 0;
-if (__INPUT_ON_IOS && !__INPUT_ON_WEB)
+if (__INPUT_ON_IOS && !INPUT_ON_WEB)
 {
     _first_gamepad = 1;
 }

--- a/scripts/__input_binding_get_label/__input_binding_get_label.gml
+++ b/scripts/__input_binding_get_label/__input_binding_get_label.gml
@@ -1,6 +1,6 @@
 function __input_binding_get_label(_type, _value, _axis_negative)
 {
-    if (!__INPUT_ON_DESKTOP)
+    if (!INPUT_ON_PC)
     {
         //Touch bindings
         if (__INPUT_ON_PS)

--- a/scripts/__input_class_gamepad/__input_class_gamepad.gml
+++ b/scripts/__input_class_gamepad/__input_class_gamepad.gml
@@ -218,7 +218,7 @@ function __input_class_gamepad(_index) constructor
                     gamepad_remove_mapping(index);
                 }
             }
-            else if (!__INPUT_ON_CONSOLE)
+            else if (!INPUT_ON_CONSOLE)
             {
                 __input_trace("Gamepad ", index, " cannot remove GameMaker's native mapping string, this feature is not supported by Input on this platform");
             }
@@ -381,7 +381,7 @@ function __input_class_gamepad(_index) constructor
         var _led_type   = INPUT_GAMEPAD_TYPE_XBOX_360;
 
         //Handle whether gamepad index 0 is used or reserved
-        if (!__INPUT_ON_WEB && (__INPUT_ON_IOS || __INPUT_ON_SWITCH))
+        if (!INPUT_ON_WEB && (__INPUT_ON_IOS || __INPUT_ON_SWITCH))
         { 
             if (index == 0) return;
             _led_offset = -1;

--- a/scripts/__input_class_player/__input_class_player.gml
+++ b/scripts/__input_class_player/__input_class_player.gml
@@ -532,7 +532,7 @@ function __input_class_player() constructor
             
             if (INPUT_FALLBACK_PROFILE_BEHAVIOR == 1)
             {
-                if (__INPUT_ON_DESKTOP && __global.__keyboard_allowed && __global.__any_keyboard_binding_defined)
+                if (INPUT_ON_PC && __global.__keyboard_allowed && __global.__any_keyboard_binding_defined)
                 {
                     //Try to use a keyboard profile if possible
                     _profile_name = INPUT_AUTO_PROFILE_FOR_KEYBOARD;
@@ -1393,7 +1393,7 @@ function __input_class_player() constructor
                 break;
 
                 case INPUT_COORD_SPACE.DEVICE:
-                    if (!__INPUT_ON_CONSOLE && (window_get_width != undefined))
+                    if (!INPUT_ON_CONSOLE && (window_get_width != undefined))
                     {
                         __gyro_screen_width  = window_get_width();
                         __gyro_screen_height = window_get_height();

--- a/scripts/__input_class_source/__input_class_source.gml
+++ b/scripts/__input_class_source/__input_class_source.gml
@@ -172,16 +172,16 @@ function __input_class_source(_source, _gamepad = undefined) constructor
                     break;
                     
                     case mb_right: //Invalid on Xbox, Playstation, native Android or iOS
-                        return !(__INPUT_ON_XBOX || __INPUT_ON_PS || (!__INPUT_ON_WEB && __INPUT_ON_MOBILE));
+                        return !(__INPUT_ON_XBOX || __INPUT_ON_PS || (!INPUT_ON_WEB && INPUT_ON_MOBILE));
                     break;
                     
                     case mb_middle: //Invalid on console, Android or iOS
-                        return !(__INPUT_ON_CONSOLE || __INPUT_ON_MOBILE);
+                        return !(INPUT_ON_CONSOLE || INPUT_ON_MOBILE);
                     break;
                     
                     case mb_side1:
                     case mb_side2: //Invalid on console, OperaGX, mobile, Firefox or Mac browsers
-                        return !(__INPUT_ON_CONSOLE || __INPUT_ON_OPERAGX || __INPUT_ON_MOBILE || (os_browser == browser_firefox) || (__INPUT_ON_WEB && __INPUT_ON_MACOS));
+                        return !(INPUT_ON_CONSOLE || __INPUT_ON_OPERAGX || INPUT_ON_MOBILE || (os_browser == browser_firefox) || (INPUT_ON_WEB && __INPUT_ON_MACOS));
                     break;
                     
                     default:
@@ -201,7 +201,7 @@ function __input_class_source(_source, _gamepad = undefined) constructor
                 if not ((__source == __INPUT_SOURCE.MOUSE) || (INPUT_ASSIGN_KEYBOARD_AND_MOUSE_TOGETHER && (__source == __INPUT_SOURCE.KEYBOARD))) return false;
                 
                 //Invalid on console or native mobile
-                return !(__INPUT_ON_CONSOLE || (!__INPUT_ON_WEB && __INPUT_ON_MOBILE));        
+                return !(INPUT_ON_CONSOLE || (!INPUT_ON_WEB && INPUT_ON_MOBILE));        
             break;
             
             case __INPUT_BINDING_VIRTUAL_BUTTON:

--- a/scripts/__input_gamepad_set_mapping/__input_gamepad_set_mapping.gml
+++ b/scripts/__input_gamepad_set_mapping/__input_gamepad_set_mapping.gml
@@ -159,7 +159,7 @@ function __input_gamepad_set_mapping()
         return;
     }
     
-    if (__INPUT_ON_WEB)
+    if (INPUT_ON_WEB)
     {
         set_mapping(gp_face1, 0, __INPUT_MAPPING.BUTTON, "a");
         set_mapping(gp_face2, 1, __INPUT_MAPPING.BUTTON, "b");

--- a/scripts/__input_gamepad_set_vid_pid/__input_gamepad_set_vid_pid.gml
+++ b/scripts/__input_gamepad_set_vid_pid/__input_gamepad_set_vid_pid.gml
@@ -2,7 +2,7 @@
 
 function __input_gamepad_set_vid_pid()
 {    
-    if (__INPUT_ON_WEB)
+    if (INPUT_ON_WEB)
     {
         vendor  = "";
         product = "";

--- a/scripts/__input_hotswap_tick/__input_hotswap_tick.gml
+++ b/scripts/__input_hotswap_tick/__input_hotswap_tick.gml
@@ -123,7 +123,7 @@ function __input_hotswap_tick_input()
             var _sort_order = 1;
             _g = 0;
             
-            if (!__INPUT_ON_WEB && (__INPUT_ON_MACOS || (!_global.__using_steamworks && __INPUT_ON_WINDOWS) || (_global.__using_steamworks && __INPUT_ON_LINUX)))
+            if (!INPUT_ON_WEB && (__INPUT_ON_MACOS || (!_global.__using_steamworks && __INPUT_ON_WINDOWS) || (_global.__using_steamworks && __INPUT_ON_LINUX)))
             {
                 //Search last-to-first on platforms with low-index virtual controllers (Steam Input, ViGEm)
                 _sort_order = -1;

--- a/scripts/__input_initialize/__input_initialize.gml
+++ b/scripts/__input_initialize/__input_initialize.gml
@@ -23,7 +23,7 @@ function __input_initialize()
     }
     
     //Detect GameMaker version to toggle features
-    _global.__use_is_instanceof = (!__INPUT_ON_WEB) && (string_copy(GM_runtime_version, 1, 4) == "2023");
+    _global.__use_is_instanceof = (!INPUT_ON_WEB) && (string_copy(GM_runtime_version, 1, 4) == "2023");
     _global.__use_legacy_strings = (string_copy(GM_runtime_version, 1, 8) == "2022.0.0");
     if (!__INPUT_SILENT)
     {
@@ -202,11 +202,11 @@ function __input_initialize()
     _global.__any_gamepad_binding_defined  = false;
     
     //Disallow keyboard bindings on specified platforms unless explicitly enabled
-    _global.__keyboard_allowed  = ((__INPUT_ON_DESKTOP && INPUT_PC_KEYBOARD)       || (__INPUT_ON_SWITCH && INPUT_SWITCH_KEYBOARD)  || (__INPUT_ON_MOBILE  && INPUT_MOBILE_WEB_KEYBOARD && __INPUT_ON_WEB) || (__INPUT_ON_ANDROID && INPUT_ANDROID_KEYBOARD));
-    _global.__mouse_allowed     = ((__INPUT_ON_DESKTOP && INPUT_PC_MOUSE)          || (__INPUT_ON_SWITCH && INPUT_SWITCH_MOUSE)     || (__INPUT_ON_MOBILE  && INPUT_MOBILE_MOUSE) || (__INPUT_ON_PS && INPUT_PS_MOUSE));
-    _global.__touch_allowed     = ((__INPUT_ON_WINDOWS && INPUT_WINDOWS_TOUCH)     || (__INPUT_ON_SWITCH && INPUT_SWITCH_TOUCH)     ||  __INPUT_ON_MOBILE) && !_global.__mouse_allowed;
-    _global.__vibration_allowed = ((__INPUT_ON_WINDOWS && INPUT_WINDOWS_VIBRATION) || (__INPUT_ON_SWITCH && INPUT_SWITCH_VIBRATION) || (__INPUT_ON_XBOX    && INPUT_XBOX_VIBRATION) || (__INPUT_ON_PS4 && INPUT_PS4_VIBRATION) || (__INPUT_ON_PS5 && INPUT_PS5_VIBRATION));
-    _global.__gamepad_allowed   = ((__INPUT_ON_DESKTOP && INPUT_PC_GAMEPAD)        ||  __INPUT_ON_CONSOLE                           || (__INPUT_ON_MOBILE  && INPUT_MOBILE_GAMEPAD));
+    _global.__keyboard_allowed  = ((INPUT_ON_PC && INPUT_PC_KEYBOARD)              || (__INPUT_ON_SWITCH && INPUT_SWITCH_KEYBOARD)  || (INPUT_ON_MOBILE  && INPUT_MOBILE_WEB_KEYBOARD && INPUT_ON_WEB) || (__INPUT_ON_ANDROID && INPUT_ANDROID_KEYBOARD));
+    _global.__mouse_allowed     = ((INPUT_ON_PC && INPUT_PC_MOUSE)                 || (__INPUT_ON_SWITCH && INPUT_SWITCH_MOUSE)     || (INPUT_ON_MOBILE  && INPUT_MOBILE_MOUSE) || (__INPUT_ON_PS && INPUT_PS_MOUSE));
+    _global.__touch_allowed     = ((__INPUT_ON_WINDOWS && INPUT_WINDOWS_TOUCH)     || (__INPUT_ON_SWITCH && INPUT_SWITCH_TOUCH)     ||  INPUT_ON_MOBILE) && !_global.__mouse_allowed;
+    _global.__vibration_allowed = ((__INPUT_ON_WINDOWS && INPUT_WINDOWS_VIBRATION) || (__INPUT_ON_SWITCH && INPUT_SWITCH_VIBRATION) || (__INPUT_ON_XBOX  && INPUT_XBOX_VIBRATION) || (__INPUT_ON_PS4 && INPUT_PS4_VIBRATION) || (__INPUT_ON_PS5 && INPUT_PS5_VIBRATION));
+    _global.__gamepad_allowed   = ((INPUT_ON_PC && INPUT_PC_GAMEPAD)               ||  INPUT_ON_CONSOLE                             || (INPUT_ON_MOBILE  && INPUT_MOBILE_GAMEPAD));
 
     //Whether mouse is blocked due to Window focus state
     _global.__window_focus_block_mouse = false;
@@ -391,7 +391,7 @@ function __input_initialize()
     _global.__raw_type_dictionary = {};
 
     //Load the controller type database
-    if (__INPUT_ON_CONSOLE || __INPUT_ON_OPERAGX || __INPUT_ON_IOS)
+    if (INPUT_ON_CONSOLE || __INPUT_ON_OPERAGX || __INPUT_ON_IOS)
     {
         if (!__INPUT_SILENT) __input_trace("Skipping loading controller type database");
     }
@@ -557,7 +557,7 @@ function __input_initialize()
     }
    
     //F13 to F32 on Windows and Web
-    if (__INPUT_ON_WINDOWS || __INPUT_ON_WEB)
+    if (__INPUT_ON_WINDOWS || INPUT_ON_WEB)
     {
         for(var _i = vk_f1 + 12; _i < vk_f1 + 32; _i++) __input_key_name_set(_i, "f" + string(_i));
     }
@@ -585,12 +585,12 @@ function __input_initialize()
         
         input_ignore_key_add(0xFF); //Vendor key
         
-        if (__INPUT_ON_MOBILE && __INPUT_ON_APPLE)
+        if (INPUT_ON_MOBILE && __INPUT_ON_APPLE)
         {
             input_ignore_key_add(124); //Screenshot
         }
         
-        if (__INPUT_ON_WEB)
+        if (INPUT_ON_WEB)
         {
             if (__INPUT_ON_APPLE)
             {
@@ -610,7 +610,7 @@ function __input_initialize()
         input_ignore_key_add(vk_numlock);   //Num Lock
         input_ignore_key_add(vk_scrollock); //Scroll Lock
         
-        if (__INPUT_ON_WEB || __INPUT_ON_WINDOWS)
+        if (INPUT_ON_WEB || __INPUT_ON_WINDOWS)
         {
             input_ignore_key_add(0x15); //IME Kana/Hanguel
             input_ignore_key_add(0x16); //IME On
@@ -862,11 +862,11 @@ function __input_initialize()
     
     #region Keyboard type
     
-    if (__INPUT_ON_CONSOLE || (__INPUT_ON_WEB && !__INPUT_ON_DESKTOP))
+    if (INPUT_ON_CONSOLE || (INPUT_ON_WEB && !INPUT_ON_PC))
     {
         INPUT_KEYBOARD_TYPE = "async";
     }
-    else if (__INPUT_ON_MOBILE)
+    else if (INPUT_ON_MOBILE)
     {
         INPUT_KEYBOARD_TYPE = "virtual";
         if (__INPUT_ON_ANDROID)
@@ -897,7 +897,7 @@ function __input_initialize()
     
     #region Pointer type
     
-    if (__input_global().__on_steam_deck || __INPUT_ON_SWITCH || __INPUT_ON_MOBILE || (__INPUT_ON_WINDOWS && _global.__touch_allowed))
+    if (__input_global().__on_steam_deck || __INPUT_ON_SWITCH || INPUT_ON_MOBILE || (__INPUT_ON_WINDOWS && _global.__touch_allowed))
     {
         INPUT_POINTER_TYPE = "touch";
     }
@@ -905,7 +905,7 @@ function __input_initialize()
     {
         INPUT_POINTER_TYPE = "touchpad";
     }
-    else if (__INPUT_ON_CONSOLE)
+    else if (INPUT_ON_CONSOLE)
     {
         INPUT_POINTER_TYPE = "none";
     }

--- a/scripts/__input_macros/__input_macros.gml
+++ b/scripts/__input_macros/__input_macros.gml
@@ -36,10 +36,11 @@
 #macro __INPUT_BINDING_GAMEPAD_BUTTON    "gamepad button"
 #macro __INPUT_BINDING_GAMEPAD_AXIS      "gamepad axis"
 
-#macro INPUT_KEYBOARD      __input_global().__source_keyboard
-#macro INPUT_MOUSE         __input_global().__source_mouse
-#macro INPUT_GAMEPAD       __input_global().__source_gamepad
-#macro INPUT_TOUCH         __input_global().__source_touch
+#macro INPUT_KEYBOARD  __input_global().__source_keyboard
+#macro INPUT_MOUSE     __input_global().__source_mouse
+#macro INPUT_GAMEPAD   __input_global().__source_gamepad
+#macro INPUT_TOUCH     __input_global().__source_touch
+
 #macro INPUT_MAX_GAMEPADS  12
 
 #macro INPUT_KEYBOARD_LOCALE  __input_global().__keyboard_locale
@@ -48,13 +49,11 @@
 
 #macro INPUT_VIRTUAL_BACKGROUND  __input_global().__virtual_background
 
-#macro __INPUT_ON_MOBILE   __input_global().__on_mobile
-#macro __INPUT_ON_DESKTOP  __input_global().__on_desktop
+
 
 #macro __INPUT_ON_PS       ((os_type == os_ps4)     || (os_type == os_ps5))
 #macro __INPUT_ON_XBOX     ((os_type == os_xboxone) || (os_type == os_xboxseriesxs))
 #macro __INPUT_ON_SWITCH   (os_type == os_switch)
-#macro __INPUT_ON_CONSOLE  (__INPUT_ON_XBOX || __INPUT_ON_PS || __INPUT_ON_SWITCH)
 
 #macro __INPUT_ON_ANDROID  (os_type == os_android)
 #macro __INPUT_ON_IOS      ((os_type == os_ios) || (os_type == os_tvos))
@@ -65,12 +64,19 @@
 #macro __INPUT_ON_APPLE    (__INPUT_ON_MACOS || __INPUT_ON_IOS)
 
 #macro __INPUT_ON_OPERAGX  (os_type == os_operagx)
-#macro __INPUT_ON_WEB      ((os_browser != browser_not_a_browser) || __INPUT_ON_OPERAGX)
 
-#macro __INPUT_SDL2_SUPPORT         (!__INPUT_ON_WEB && (__INPUT_ON_DESKTOP || __INPUT_ON_ANDROID))
-#macro __INPUT_KEYBOARD_NORMATIVE   (__INPUT_ON_DESKTOP || __INPUT_ON_WEB || __INPUT_ON_SWITCH)
-#macro __INPUT_LED_PATTERN_SUPPORT  ((os_type == os_ps5) || __INPUT_ON_SWITCH || __INPUT_ON_IOS || (__INPUT_ON_WINDOWS && !__INPUT_ON_WEB))
-#macro __INPUT_STEAMWORKS_SUPPORT   ((__INPUT_ON_LINUX || __INPUT_ON_WINDOWS) && !__INPUT_ON_WEB)
+#macro INPUT_ON_MOBILE      __input_global().__on_mobile
+#macro INPUT_ON_PC          __input_global().__on_desktop
+#macro INPUT_ON_STEAM_DECK  __input_global().__on_steam_deck
+#macro INPUT_ON_CONSOLE    (__INPUT_ON_XBOX || __INPUT_ON_PS || __INPUT_ON_SWITCH)
+#macro INPUT_ON_WEB        ((os_browser != browser_not_a_browser) || __INPUT_ON_OPERAGX)
+
+
+
+#macro __INPUT_SDL2_SUPPORT         (!INPUT_ON_WEB && (INPUT_ON_PC || __INPUT_ON_ANDROID))
+#macro __INPUT_KEYBOARD_NORMATIVE   (INPUT_ON_PC || INPUT_ON_WEB || __INPUT_ON_SWITCH)
+#macro __INPUT_LED_PATTERN_SUPPORT  ((os_type == os_ps5) || __INPUT_ON_SWITCH || __INPUT_ON_IOS || (__INPUT_ON_WINDOWS && !INPUT_ON_WEB))
+#macro __INPUT_STEAMWORKS_SUPPORT   ((__INPUT_ON_LINUX || __INPUT_ON_WINDOWS) && !INPUT_ON_WEB)
 
 #macro __INPUT_HOLD_THRESHOLD           0.2  //Minimum value from an axis for that axis to be considered activated at the gamepad layer. This is *not* the same as min/max thresholds for players
 #macro __INPUT_DELTA_HOTSWAP_THRESHOLD  0.1  //Minimum (absolute) change in gamepad mapping value between frames to register as new input. This triggers hotswapping
@@ -123,11 +129,11 @@
 #macro vk_lbracket    219
 #macro vk_rbracket    221
 
-#macro vk_apostrophe ((__INPUT_ON_MACOS && !__INPUT_ON_WEB)? 192 : 222)
-#macro vk_equals     ((__INPUT_ON_MACOS && !__INPUT_ON_WEB)?  24 : 187)
-#macro vk_numlock    ((__INPUT_ON_APPLE &&  __INPUT_ON_WEB)?  12 : 144)
-#macro vk_hyphen     ((__INPUT_ON_SWITCH || (__INPUT_ON_MACOS && !__INPUT_ON_WEB))? 109 : 189)
-#macro vk_rmeta      (__INPUT_ON_MACOS? ((__INPUT_ON_APPLE && __INPUT_ON_WEB)? 93 : 91) : 92)
+#macro vk_apostrophe ((__INPUT_ON_MACOS && !INPUT_ON_WEB)? 192 : 222)
+#macro vk_equals     ((__INPUT_ON_MACOS && !INPUT_ON_WEB)?  24 : 187)
+#macro vk_numlock    ((__INPUT_ON_APPLE &&  INPUT_ON_WEB)?  12 : 144)
+#macro vk_hyphen     ((__INPUT_ON_SWITCH || (__INPUT_ON_MACOS && !INPUT_ON_WEB))? 109 : 189)
+#macro vk_rmeta      (__INPUT_ON_MACOS? ((__INPUT_ON_APPLE && INPUT_ON_WEB)? 93 : 91) : 92)
 #macro vk_backtick   (__INPUT_ON_MACOS?   50 : (__INPUT_ON_LINUX? 223 : 192))
 #macro vk_lmeta      (__INPUT_ON_MACOS?   92 :  91)
 #macro vk_period     (__INPUT_ON_SWITCH? 110 : 190)

--- a/scripts/__input_mouse_button/__input_mouse_button.gml
+++ b/scripts/__input_mouse_button/__input_mouse_button.gml
@@ -16,7 +16,7 @@ function __input_mouse_button()
             return mb_left;
         }
     }
-    else if (__INPUT_ON_DESKTOP && !__INPUT_ON_WEB)
+    else if (INPUT_ON_PC && !INPUT_ON_WEB)
     {
         //Desktop native
         if (mouse_button != mb_none)

--- a/scripts/__input_system_tick/__input_system_tick.gml
+++ b/scripts/__input_system_tick/__input_system_tick.gml
@@ -96,7 +96,7 @@ function __input_system_tick()
     
     #region Window focus
     
-    if (__INPUT_ON_DESKTOP && !__INPUT_ON_WEB)
+    if (INPUT_ON_PC && !INPUT_ON_WEB)
     {
         if (os_is_paused())
         {
@@ -340,7 +340,7 @@ function __input_system_tick()
     if (_global.__keyboard_allowed && keyboard_check(vk_anykey))
     {
         var _platform = os_type;
-        if (__INPUT_ON_WEB && __INPUT_ON_APPLE) _platform = "apple_web";
+        if (INPUT_ON_WEB && __INPUT_ON_APPLE) _platform = "apple_web";
 
         switch (_platform)
         {

--- a/scripts/input_mouse_capture_set/input_mouse_capture_set.gml
+++ b/scripts/input_mouse_capture_set/input_mouse_capture_set.gml
@@ -9,7 +9,7 @@ function input_mouse_capture_set(_state, _sensitivity = 1)
     static _monitor_coords       = undefined; 
     static _monitor_update_frame = -infinity;
     
-    if (!__INPUT_ON_DESKTOP || __INPUT_ON_WEB)
+    if (!INPUT_ON_PC || INPUT_ON_WEB)
     {
         if (__INPUT_DEBUG_CAPTURE) __input_trace("Mouse capture unsupported for this platform");
         return;

--- a/scripts/input_source_detect_new/input_source_detect_new.gml
+++ b/scripts/input_source_detect_new/input_source_detect_new.gml
@@ -9,7 +9,7 @@ function input_source_detect_new()
     var _sort_order = 1;
     var _g = 0;
     
-    if (!__INPUT_ON_WEB && (__INPUT_ON_MACOS || (!_global.__using_steamworks && __INPUT_ON_WINDOWS) || (_global.__using_steamworks && __INPUT_ON_LINUX)))
+    if (!INPUT_ON_WEB && (__INPUT_ON_MACOS || (!_global.__using_steamworks && __INPUT_ON_WINDOWS) || (_global.__using_steamworks && __INPUT_ON_LINUX)))
     {
         //Search last-to-first on platforms with low-index virtual controllers (Steam Input, ViGEm)
         //We want real devices to take priority over virtual ones where possible to avoid thrashing


### PR DESCRIPTION
Exposes `.._ON_MOBILE`, `.._ON_PC`, `.._ON_STEAM_DECK`, `.._ON_CONSOLE`, `.._ON_WEB`. 
Similar idea as with `.._POINTER_TYPE` (empowers per-platform configuration), less abstract