### PR TITLE
Fix two virtual button bugs

### DIFF
--- a/scripts/__input_system_tick/__input_system_tick.gml
+++ b/scripts/__input_system_tick/__input_system_tick.gml
@@ -525,11 +525,12 @@ function __input_system_tick()
     //Reorder virtual buttons if necessary, from highest priority to lowest
     if (_global.__virtual_order_dirty)
     {
-        //Clean up any destroyed virtual buttons
+        //Clean up any destroyed virtual buttons, and temporarily remove background
         var _i = 0;
         repeat(array_length(_global.__virtual_array))
         {
-            if (_global.__virtual_array[_i].__destroyed)
+            var _button = _global.__virtual_array[_i];
+            if (_button.__destroyed || _button.__background)
             {
                 array_delete(_global.__virtual_array, _i, 1);
             }
@@ -539,11 +540,16 @@ function __input_system_tick()
             }
         }
         
-        _global.__virtual_order_dirty = false;
+        //Perform actual sort
         array_sort(_global.__virtual_array, function(_a, _b)
         {
             return _b.__priority - _a.__priority;
         });
+        
+        //Re-add background virtual button
+        array_push(_global.__virtual_array, _global.__virtual_background);
+        
+        _global.__virtual_order_dirty = false;
     }
     
     if (is_struct(_global.__touch_player))

--- a/scripts/__input_system_tick/__input_system_tick.gml
+++ b/scripts/__input_system_tick/__input_system_tick.gml
@@ -532,12 +532,11 @@ function __input_system_tick()
     //Reorder virtual buttons if necessary, from highest priority to lowest
     if (_global.__virtual_order_dirty)
     {
-        //Clean up any destroyed virtual buttons, and temporarily remove background
+        //Clean up any destroyed virtual buttons
         var _i = 0;
         repeat(array_length(_global.__virtual_array))
         {
-            var _button = _global.__virtual_array[_i];
-            if (_button.__destroyed || _button.__background)
+            if (_global.__virtual_array[_i].__destroyed)
             {
                 array_delete(_global.__virtual_array, _i, 1);
             }
@@ -547,16 +546,11 @@ function __input_system_tick()
             }
         }
         
-        //Perform actual sort
+        _global.__virtual_order_dirty = false;
         array_sort(_global.__virtual_array, function(_a, _b)
         {
-            return _b.__priority - _a.__priority;
+            return sign(_b.__priority - _a.__priority);
         });
-        
-        //Re-add background virtual button
-        array_push(_global.__virtual_array, _global.__virtual_background);
-        
-        _global.__virtual_order_dirty = false;
     }
     
     if (is_struct(_global.__touch_player))

--- a/scripts/input_virtual_destroy_all/input_virtual_destroy_all.gml
+++ b/scripts/input_virtual_destroy_all/input_virtual_destroy_all.gml
@@ -7,7 +7,7 @@ function input_virtual_destroy_all()
     var _i = 0;
     repeat(array_length(_global.__virtual_array))
     {
-        with(_global.__verb_group_array[_i])
+        with(_global.__virtual_array[_i])
         {
             if (!__background) destroy();
         }


### PR DESCRIPTION
- Background virtual button sometimes would be sorted incorrectly due to its priority being `-infinity`. (Seems like a GameMaker problem?): this PR forces it to always be at the end of the array
- input_virtual_destroy_all() didn't work at all, used the wrong variable name

Note that the first fix is incorrect if the background virtual button is supposed to be able to have its priority changed. If that's the case, feel free to remove those changes and simply change the `-infinity` on the background button to an arbitrarily-small number like `-1000000`.