### PR TITLE
Fix Steam Deck power button sticking, prevent key scanning returning "any" on out of range values

### DIFF
--- a/scripts/__input_hotswap_tick/__input_hotswap_tick.gml
+++ b/scripts/__input_hotswap_tick/__input_hotswap_tick.gml
@@ -195,6 +195,7 @@ function __input_hotswap_tick_input()
     if (_global.__keyboard_allowed && _global.__any_keyboard_binding_defined
     &&  input_source_is_available(INPUT_KEYBOARD)
     &&  keyboard_check(vk_anykey)
+    &&  (__input_keyboard_key() > 0) //Ensure that the key is in the recognized range
     &&  !__input_key_is_ignored(__input_keyboard_key())) //Ensure that this key isn't one we're trying to ignore
     {
         if (__INPUT_DEBUG_SOURCES) __input_trace("Hotswapping player 0 to ", INPUT_KEYBOARD);

--- a/scripts/__input_initialize/__input_initialize.gml
+++ b/scripts/__input_initialize/__input_initialize.gml
@@ -621,6 +621,11 @@ function __input_initialize()
         
         input_ignore_key_add(0xFF); //Vendor key
         
+        if (__INPUT_ON_WINDOWS)
+        {
+            input_ignore_key_add(0xE6); //OEM key (Power button on Steam Deck)
+        }
+        
         if (INPUT_ON_MOBILE && __INPUT_ON_APPLE)
         {
             input_ignore_key_add(124); //Screenshot

--- a/scripts/__input_keyboard_key/__input_keyboard_key.gml
+++ b/scripts/__input_keyboard_key/__input_keyboard_key.gml
@@ -36,11 +36,19 @@ function __input_keyboard_key()
                     if (keyboard_check(_i)) return _i;
                     --_i;
                 }
+
                 return 0;
             break;
             
             default:
-                return keyboard_key;
+
+            	//Don't return "any" (key is out of range)
+                if (keyboard_key == 1) 
+                {
+                	return 0;
+            	}
+
+            	return keyboard_key;
             break;
         }
     }

--- a/scripts/__input_system_tick/__input_system_tick.gml
+++ b/scripts/__input_system_tick/__input_system_tick.gml
@@ -354,9 +354,15 @@ function __input_system_tick()
                     keyboard_key_release(vk_lalt);
                     keyboard_key_release(vk_ralt);
                 }
+
+                if (keyboard_check(0xE6) && !keyboard_check_pressed(0xE6))
+                {
+                    //Unstick OEM key (Power button on Steam Deck)
+                    keyboard_key_release(0x0E6);
+                }
             break;            
             case "apple_web": //This case applies on iOS, tvOS, and MacOS
-                if (keyboard_check_released(92) || keyboard_check_released(93))
+                if (keyboard_check_released(vk_lmeta) || keyboard_check_released(vk_rmeta))
                 {
                     //Meta release sticks every key pressed during hold
                     //This is "the nuclear option", but the problem is severe


### PR DESCRIPTION
closes #755