### PR TITLE
Consume verbs on restart (prevents `game_restart` loop)

### DIFF
--- a/objects/input_controller_object/Other_3.gml
+++ b/objects/input_controller_object/Other_3.gml
@@ -1,1 +1,2 @@
+input_verb_consume(all, all);
 __input_restart_set(true);

--- a/scripts/__input_gamepad_set_blacklist/__input_gamepad_set_blacklist.gml
+++ b/scripts/__input_gamepad_set_blacklist/__input_gamepad_set_blacklist.gml
@@ -18,7 +18,7 @@ function __input_gamepad_set_blacklist()
 
     //Filter non-gamepad joystick devices
     if ((!INPUT_SDL2_ALLOW_NONGAMEPAD_JOYSTICKS)
-    &&  (__input_string_contains(raw_type, "Wheel", "Flightstick", "Throttle", "Guitar", "Drumkit", "Dancepad, "Skateboard"))
+    &&  (__input_string_contains(raw_type, "Wheel", "Flightstick", "Throttle", "Guitar", "Drumkit", "Dancepad", "Skateboard")))
     {
         if (!__INPUT_SILENT) __input_trace("Warning! Device ", index, " is blacklisted (Not a gamepad)");
         blacklisted = true;

--- a/scripts/__input_restart_set/__input_restart_set.gml
+++ b/scripts/__input_restart_set/__input_restart_set.gml
@@ -2,5 +2,9 @@
 function __input_restart_set(_state)
 {
     __INPUT_GLOBAL_STATIC_LOCAL  //Set static _global
+    if (_state && !_global.__restart)
+    {
+        input_verb_consume(all, all);
+    }
     _global.__restart = _state;
 }


### PR DESCRIPTION
This remedies an edge case involving #780, where Input will end up in an game_restart infinite loop. The solution is to consume all verbs from all players as the game ends, preventing an infinite loop.

This PR also adds in a slight remedy to `__input_gamepad_set_blacklist`, preventing the game from starting up at all. (Missing quote and parentheses)