### PR TITLE
Address misconfigured touch source earlier, update error messages

### DIFF
--- a/scripts/__input_finalize_default_profiles/__input_finalize_default_profiles.gml
+++ b/scripts/__input_finalize_default_profiles/__input_finalize_default_profiles.gml
@@ -7,7 +7,7 @@ function __input_finalize_default_profiles()
     
     if (!is_struct(_global.__default_profile_dict))
     {
-        __input_error("__input_config_verbs() must contain a struct (was ", typeof(_global.__default_profile_dict), ")\nDocumentation on __input_config_verbs() can be found offline in __input_config_verbs_and_bindings()\nOnline documentation can be found at https://jujuadams.github.io/Input");
+        __input_error("__input_config_verbs() must contain a struct (was ", typeof(_global.__default_profile_dict), ")\nDocumentation on __input_config_verbs() can be found offline in __input_config_verbs()\nOnline documentation can be found at https://jujuadams.github.io/Input");
     }
     
     if (variable_struct_names_count(_global.__default_profile_dict) <= 0)
@@ -104,6 +104,22 @@ function __input_finalize_default_profiles()
         }
         
         ++_f;
+    }
+    
+    //Identify misconfigured touch source on potential touch platforms when starting in hotswap mode
+    if ((INPUT_STARTING_SOURCE_MODE == INPUT_SOURCE_MODE.HOTSWAP) && !_global.__any_touch_binding_defined)
+    {
+        //Immediately address missing touch bindings
+        if (_global.__touch_allowed)
+        {
+            __input_error("Touch bindings are not configured. Create virtual button bindings in a default profile (see __input_config_verbs()), or change mouse/touch configuration for this platform (see __input_config_general())");
+        }
+        
+        //Present a mobile web misconfiguration warning on desktop web
+        if (INPUT_ON_WEB && !INPUT_ON_MOBILE && !INPUT_MOBILE_MOUSE)
+        {
+            __input_trace_loud("Warning!\n\nTouch bindings are not configured for mobile web. Create virtual button bindings in a default profile (see __input_config_verbs()) or set \"INPUT_MOBILE_MOUSE\" to <true> to use mouse bindings (see __input_config_general()) to ensure compatibility on mobile web\n\n\nInput ", __INPUT_VERSION, "   @jujuadams and @offalynne ", __INPUT_DATE);
+        }
     }
     
     if (!__INPUT_SILENT)

--- a/scripts/__input_initialize/__input_initialize.gml
+++ b/scripts/__input_initialize/__input_initialize.gml
@@ -52,15 +52,23 @@ function __input_initialize()
     }
     
     //Detect new string functions, which offer a significant performance gain when reading the SDL2 database
-    try
+    if (INPUT_ON_WEB)
     {
-        string_split("Juju\nwaz\nere", "\n", true);
-        string_trim("         you can't catch me          ");
+        //Buggy as of 2023-10-08
         _global.__use_legacy_strings = false;
     }
-    catch(_error)
+    else 
     {
-        _global.__use_legacy_strings = true;
+        try
+        {
+            string_split("Juju\nwaz\nere", "\n", true);
+            string_trim("         you can't catch me          ");
+            _global.__use_legacy_strings = false;
+        }
+        catch(_error)
+        {
+            _global.__use_legacy_strings = true;
+        }
     }
     
     if (not __INPUT_SILENT)
@@ -69,14 +77,22 @@ function __input_initialize()
     }
     
     //Detect is_debug_overlay_open() to block game input to overlay, if supported
-    try
+    if (INPUT_ON_WEB)
     {
-        is_debug_overlay_open();
-        _global.__use_debug_overlay_status = true;
-    }
-    catch(_error)
-    {
+        //Buggy as of 2023-10-08
         _global.__use_debug_overlay_status = false;
+    }
+    else 
+    {
+        try
+        {
+            is_debug_overlay_open();
+            _global.__use_debug_overlay_status = true;
+        }
+        catch(_error)
+        {
+            _global.__use_debug_overlay_status = false;
+        }
     }
     
     if not (__INPUT_SILENT)
@@ -84,14 +100,22 @@ function __input_initialize()
         __input_trace(_global.__use_debug_overlay_status? "Using debug overlay status to block input" : "Debug overlay status is unavailable");
     }
     
-    try
+    if (INPUT_ON_WEB)
     {
-        ref_create({});
-        _global.__allow_gamepad_tester = true;
-    }
-    catch(_error)
-    {
+        //Buggy as of 2023-10-08
         _global.__allow_gamepad_tester = false;
+    }
+    else 
+    {
+        try
+        {
+            ref_create({});
+            _global.__allow_gamepad_tester = true;
+        }
+        catch(_error)
+        {
+            _global.__allow_gamepad_tester = false;
+        }
     }
     
     if not (__INPUT_SILENT)
@@ -263,7 +287,7 @@ function __input_initialize()
     _global.__on_desktop = (__INPUT_ON_WINDOWS || __INPUT_ON_MACOS || __INPUT_ON_LINUX || __INPUT_ON_OPERAGX);
     _global.__on_mobile  = (__INPUT_ON_ANDROID || __INPUT_ON_IOS);
     
-    //OperaGX mobile identity per YYG
+    //OperaGX mobile identity
     if (__INPUT_ON_OPERAGX)
     {
         var _map = os_get_info();
@@ -273,6 +297,7 @@ function __input_initialize()
             {
                 _global.__on_mobile  = true;
                 _global.__on_desktop = false;
+                if (!__INPUT_SILENT) __input_trace("Browser indicates OperaGX mobile");
             }
 
             ds_map_destroy(_map);
@@ -526,33 +551,32 @@ function __input_initialize()
     #endregion
     
     
-    #region
+    #region Gamepad LED patterns by device type
     
-    //Gamepad LED patterns by device type
-    _global.__gamepad_led_pattern_dict = {
-        INPUT_GAMEPAD_TYPE_PS5: [                 //PS5
-            [false, false, true,  false, false],  //P1: --X--
-            [false, true,  false, true,  false],  //P2: -X-X-
-            [true,  false, true,  false, true ],  //P3: X-X-X
-            [true,  true,  false, true,  true ],  //P4: XX-XX
-        ],        
-        INPUT_GAMEPAD_TYPE_SWITCH: [              //Switch
-            [true,  false, false, false],         //P1: X---
-            [true,  true,  false, false],         //P2: XX--
-            [true,  true,  true,  false],         //P3: XXX-
-            [true,  true,  true,  true ],         //P4: XXXX
-            [true,  false, false, true ],         //P5: X--X
-            [true,  false, true,  false],         //P6: X-X-
-            [true,  false, true,  true ],         //P7: X-XX
-            [false, true,  true,  false],         //P8: -XX-
-        ],        
-        INPUT_GAMEPAD_TYPE_XBOX_360: [            //Xbox 360
-            [true,  false, false, false],         //P1: X---
-            [false, true,  false, false],         //P2: -X--
-            [false, false, true,  false],         //P3: --X-
-            [false, false, false, true ],         //P4: ---X
-        ],
-    }
+    var _dict = {};
+    _dict[$ INPUT_GAMEPAD_TYPE_PS5] = [       //PS5
+        [false, false, true,  false, false],  //P1: --X--
+        [false, true,  false, true,  false],  //P2: -X-X-
+        [true,  false, true,  false, true ],  //P3: X-X-X
+        [true,  true,  false, true,  true ],  //P4: XX-XX
+    ];    
+    _dict[$ INPUT_GAMEPAD_TYPE_SWITCH] = [    //Switch
+        [true,  false, false, false],         //P1: X---
+        [true,  true,  false, false],         //P2: XX--
+        [true,  true,  true,  false],         //P3: XXX-
+        [true,  true,  true,  true ],         //P4: XXXX
+        [true,  false, false, true ],         //P5: X--X
+        [true,  false, true,  false],         //P6: X-X-
+        [true,  false, true,  true ],         //P7: X-XX
+        [false, true,  true,  false],         //P8: -XX-
+    ];
+    _dict[$ INPUT_GAMEPAD_TYPE_XBOX_360] = [  //Xbox 360
+        [true,  false, false, false],         //P1: X---
+        [false, true,  false, false],         //P2: -X--
+        [false, false, true,  false],         //P3: --X-
+        [false, false, false, true ],         //P4: ---X
+    ];    
+    _global.__gamepad_led_pattern_dict = _dict;
     
     #endregion
 

--- a/scripts/__input_macros/__input_macros.gml
+++ b/scripts/__input_macros/__input_macros.gml
@@ -351,14 +351,14 @@ enum INPUT_VIRTUAL_RELEASE
                                              {\
                                                  if (!_global.__any_keyboard_binding_defined && !_global.__any_mouse_binding_defined)\
                                                  {\
-                                                    __input_error("Cannot claim ", _source, ", no keyboard or mouse bindings have been created in a default profile (see __input_config_verbs_and_bindings())");\
+                                                    __input_error("Cannot claim ", _source, ", no keyboard or mouse bindings have been created in a default profile (see __input_config_verbs())");\
                                                  }\
                                              }\
                                              else\
                                              {\
                                                  if (!_global.__any_keyboard_binding_defined)\
                                                  {\
-                                                     __input_error("Cannot claim ", _source, ", no keyboard bindings have been created in a default profile (see __input_config_verbs_and_bindings())");\
+                                                     __input_error("Cannot claim ", _source, ", no keyboard bindings have been created in a default profile (see __input_config_verbs())");\
                                                  }\
                                              }\
                                          }\
@@ -366,20 +366,20 @@ enum INPUT_VIRTUAL_RELEASE
                                          {\
                                              if (!_global.__any_mouse_binding_defined)\
                                              {\
-                                                 __input_error("Cannot claim ", _source, ", no mouse bindings have been created in a default profile (see __input_config_verbs_and_bindings())");\
+                                                 __input_error("Cannot claim ", _source, ", no mouse bindings have been created in a default profile (see __input_config_verbs())");\
                                              }\
                                          }\
                                          else if (_source == INPUT_TOUCH)\
                                          {\
                                              if (!_global.__any_touch_binding_defined)\
                                              {\
-                                                 __input_error("Cannot claim ", _source, ", no virtual button bindings have been created in a default profile (see __input_config_verbs_and_bindings())");\
+                                                 __input_error("Cannot claim ", _source, ", no virtual button bindings have been created in a default profile (see __input_config_verbs())");\
                                              }\
                                          }\
                                          else if (_source.__source == __INPUT_SOURCE.GAMEPAD)\
                                          {\
                                              if (!_global.__any_gamepad_binding_defined)\
                                              {\
-                                                 __input_error("Cannot claim ", _source, ", no gamepad bindings have been created in a default profile (see __input_config_verbs_and_bindings())");\
+                                                 __input_error("Cannot claim ", _source, ", no gamepad bindings have been created in a default profile (see __input_config_verbs())");\
                                              }\
                                          }

--- a/scripts/input_profile_reset_bindings/input_profile_reset_bindings.gml
+++ b/scripts/input_profile_reset_bindings/input_profile_reset_bindings.gml
@@ -1,5 +1,5 @@
 // Feather disable all
-/// @desc    Resets all bindings for the profile to those found in __input_config_verbs_and_bindings()
+/// @desc    Resets all bindings for the profile to those found in __input_config_verbs()
 ///          This will only work for default profiles
 /// @param   profileName
 /// @param   [playerIndex=0]


### PR DESCRIPTION
- Error immediately on touch platforms when configured to start in hotswap with missing touch bindings
- Warn immediately on desktop web if mobile web is misconfigured per above
- Correct `__input_config_verbs_and_bindings` to `__input_config_verbs` in relevant error messages