### PR TITLE
Simplify touch configuration

### DIFF
--- a/scripts/__input_finalize_default_profiles/__input_finalize_default_profiles.gml
+++ b/scripts/__input_finalize_default_profiles/__input_finalize_default_profiles.gml
@@ -15,6 +15,12 @@ function __input_finalize_default_profiles()
        __input_error("__input_config_verbs() must contain at least one profile");
     }
     
+    //Ensure touch profile on touch platform configurations
+    if (_global.__touch_allowed && !_global.__any_touch_binding_defined)
+    {       
+        _global.__default_profile_dict[$ INPUT_AUTO_PROFILE_FOR_TOUCH] = {};
+    }
+    
     //Put strict mode on, this'll cause Input to throw errors if the player does anything dumb
     _global.__strict_binding_check = true;
     
@@ -104,22 +110,6 @@ function __input_finalize_default_profiles()
         }
         
         ++_f;
-    }
-    
-    //Identify misconfigured touch source on potential touch platforms when starting in hotswap mode
-    if ((INPUT_STARTING_SOURCE_MODE == INPUT_SOURCE_MODE.HOTSWAP) && !_global.__any_touch_binding_defined)
-    {
-        //Immediately address missing touch bindings
-        if (_global.__touch_allowed)
-        {
-            __input_error("Touch bindings are not configured. Create virtual button bindings in a default profile (see __input_config_verbs()), or change mouse/touch configuration for this platform (see __input_config_general())");
-        }
-        
-        //Present a mobile web misconfiguration warning on desktop web
-        if (INPUT_ON_WEB && !INPUT_ON_MOBILE && !INPUT_MOBILE_MOUSE)
-        {
-            __input_trace_loud("Warning!\n\nTouch bindings are not configured for mobile web. Create virtual button bindings in a default profile (see __input_config_verbs()) or set \"INPUT_MOBILE_MOUSE\" to <true> to use mouse bindings (see __input_config_general()) to ensure compatibility on mobile web\n\n\nInput ", __INPUT_VERSION, "   @jujuadams and @offalynne ", __INPUT_DATE);
-        }
     }
     
     if (!__INPUT_SILENT)

--- a/scripts/__input_initialize/__input_initialize.gml
+++ b/scripts/__input_initialize/__input_initialize.gml
@@ -335,7 +335,10 @@ function __input_initialize()
         else
         {
             _global.__touch_allowed = false;
-            if (!__INPUT_SILENT) __input_trace("Warning! Mouse configuration overrides touch. Virtual buttons may not work as expected.");
+            if not (INPUT_MOUSE_ALLOW_VIRTUAL_BUTTONS)
+            {
+                if (!__INPUT_SILENT) __input_trace("Warning! Mouse configuration overrides touch. Virtual buttons may not work as expected.");
+            }
         }
     }
 

--- a/scripts/__input_initialize/__input_initialize.gml
+++ b/scripts/__input_initialize/__input_initialize.gml
@@ -319,9 +319,25 @@ function __input_initialize()
     //Disallow keyboard bindings on specified platforms unless explicitly enabled
     _global.__keyboard_allowed  = ((INPUT_ON_PC && INPUT_PC_KEYBOARD)              || (__INPUT_ON_SWITCH && INPUT_SWITCH_KEYBOARD)  || (INPUT_ON_MOBILE  && INPUT_MOBILE_WEB_KEYBOARD && INPUT_ON_WEB) || (__INPUT_ON_ANDROID && INPUT_ANDROID_KEYBOARD));
     _global.__mouse_allowed     = ((INPUT_ON_PC && INPUT_PC_MOUSE)                 || (__INPUT_ON_SWITCH && INPUT_SWITCH_MOUSE)     || (INPUT_ON_MOBILE  && INPUT_MOBILE_MOUSE) || (__INPUT_ON_PS && INPUT_PS_MOUSE));
-    _global.__touch_allowed     = ((__INPUT_ON_WINDOWS && INPUT_WINDOWS_TOUCH)     || (__INPUT_ON_SWITCH && INPUT_SWITCH_TOUCH)     ||  INPUT_ON_MOBILE) && !_global.__mouse_allowed;
+    _global.__touch_allowed     = ((__INPUT_ON_WINDOWS && INPUT_WINDOWS_TOUCH)     || (__INPUT_ON_SWITCH && INPUT_SWITCH_TOUCH)     ||  INPUT_ON_MOBILE);
     _global.__vibration_allowed = ((__INPUT_ON_WINDOWS && INPUT_WINDOWS_VIBRATION) || (__INPUT_ON_SWITCH && INPUT_SWITCH_VIBRATION) || (__INPUT_ON_XBOX  && INPUT_XBOX_VIBRATION) || ((os_type == os_ps4) && INPUT_PS4_VIBRATION) || ((os_type == os_ps5) && INPUT_PS5_VIBRATION));
     _global.__gamepad_allowed   = ((INPUT_ON_PC && INPUT_PC_GAMEPAD)               ||  INPUT_ON_CONSOLE                             || (INPUT_ON_MOBILE  && INPUT_MOBILE_GAMEPAD));
+
+    //Mouse overrides touch
+    if (_global.__mouse_allowed && _global.__touch_allowed)
+    {
+        //Except on Windows
+        if (__INPUT_ON_WINDOWS)
+        {
+            _global.__mouse_allowed = false;       
+            if (!__INPUT_SILENT) __input_trace("Warning! INPUT_WINDOWS_TOUCH overrides INPUT_PC_MOUSE. Mouse bindings may not work as expected.");
+        }
+        else
+        {
+            _global.__touch_allowed = false;
+            if (!__INPUT_SILENT) __input_trace("Warning! Mouse configuration overrides touch. Virtual buttons may not work as expected.");
+        }
+    }
 
     //Whether mouse is blocked due to Window focus state
     _global.__window_focus_block_mouse = false;

--- a/scripts/__input_macros/__input_macros.gml
+++ b/scripts/__input_macros/__input_macros.gml
@@ -369,13 +369,6 @@ enum INPUT_VIRTUAL_RELEASE
                                                  __input_error("Cannot claim ", _source, ", no mouse bindings have been created in a default profile (see __input_config_verbs())");\
                                              }\
                                          }\
-                                         else if (_source == INPUT_TOUCH)\
-                                         {\
-                                             if (!_global.__any_touch_binding_defined)\
-                                             {\
-                                                 __input_error("Cannot claim ", _source, ", no virtual button bindings have been created in a default profile (see __input_config_verbs())");\
-                                             }\
-                                         }\
                                          else if (_source.__source == __INPUT_SOURCE.GAMEPAD)\
                                          {\
                                              if (!_global.__any_gamepad_binding_defined)\


### PR DESCRIPTION
Closes #801

- An empty or missing touch profile is now allowed (docs indicate this is the intended behaviour)
- Mouse overrides touch on mobile and Switch (default off)
- Touch overrides mouse on Windows (default off)