### PR TITLE
Update input_binding_set_safe.gml

### DIFF
--- a/scripts/input_binding_set_safe/input_binding_set_safe.gml
+++ b/scripts/input_binding_set_safe/input_binding_set_safe.gml
@@ -26,7 +26,7 @@ function input_binding_set_safe(_verb_name, _binding, _player_index = 0, _altern
         var _collisions = input_binding_test_collisions(_verb_name, _binding, _player_index, _profile_name);
         if (array_length(_collisions) == 0)
         {
-            input_binding_set(_verb_name, _binding, _player_index, _alternate);
+            input_binding_set(_verb_name, _binding, _player_index, _alternate, _profile_name);
         }
         else
         {


### PR DESCRIPTION
Included _profile_name in the input_binding_set call when no collisions are found so that the passed in profile is always properly enforced.

<3