### PR TITLE
Corrections, hotswap and XInput reworks 

### DIFF
--- a/input.yyp
+++ b/input.yyp
@@ -490,9 +490,9 @@
   "IncludedFiles": [
     {"resourceType":"GMIncludedFile","resourceVersion":"1.0","name":"test_load_mapping.json","CopyToMask":-1,"filePath":"datafiles",},
     {"resourceType":"GMIncludedFile","resourceVersion":"1.0","name":"sdl2.txt","CopyToMask":-1,"filePath":"datafiles",},
-    {"resourceType":"GMIncludedFile","resourceVersion":"1.0","name":"licenses.txt","CopyToMask":-1,"filePath":"datafiles",},
     {"resourceType":"GMIncludedFile","resourceVersion":"1.0","name":"controllertypes.csv","CopyToMask":-1,"filePath":"datafiles",},
     {"resourceType":"GMIncludedFile","resourceVersion":"1.0","name":"controllerblacklist.csv","CopyToMask":-1,"filePath":"datafiles",},
+    {"resourceType":"GMIncludedFile","resourceVersion":"1.0","name":"input_license.txt","CopyToMask":-1,"filePath":"datafiles",},
   ],
   "MetaData": {
     "IDEVersion": "2022.0.1.31",

--- a/scripts/__input_class_gamepad_mapping/__input_class_gamepad_mapping.gml
+++ b/scripts/__input_class_gamepad_mapping/__input_class_gamepad_mapping.gml
@@ -20,7 +20,7 @@ function __input_class_gamepad_mapping(_gm, _raw, _type, _sdl_name) constructor
     limited_range  = false;
     extended_range = false;
     hat_mask       = undefined;
-    scale          = 256;
+    scale          = 1;
     
     //Hat-on-axis and split axis
     raw_negative = undefined;
@@ -105,7 +105,7 @@ function __input_class_gamepad_mapping(_gm, _raw, _type, _sdl_name) constructor
             if (clamp_positive) value = clamp(value,  0, 1);
             if (invert)         value = 1 - value;
                   
-            value = clamp((256/scale)*value, -1, 1);
+            value = clamp(scale*value, -1, 1);
             
             if (__value_previous == undefined)
             {

--- a/scripts/__input_config_keyboard/__input_config_keyboard.gml
+++ b/scripts/__input_config_keyboard/__input_config_keyboard.gml
@@ -13,6 +13,7 @@
 //  1 = Ignore select nonfunctional keys:
 //      - Alt/Options (Mac)
 //      - Windows/Command (Mac)
+//      - Hard/soft Back on Android
 //      - PrintSc on iOS/tvOS
 //      - Caps lock in browser on Apple platforms
 //      - F10 in browser on Apple platforms

--- a/scripts/__input_define_gamepad_types/__input_define_gamepad_types.gml
+++ b/scripts/__input_define_gamepad_types/__input_define_gamepad_types.gml
@@ -2,7 +2,7 @@
 function __input_define_gamepad_types()
 {
     __input_global().__simple_type_lookup = {};
-    with (__input_global().__simple_type_lookup)
+    with(__input_global().__simple_type_lookup)
     {
         //Xbox
         #macro INPUT_GAMEPAD_TYPE_XBOX_ONE "xbox one"

--- a/scripts/__input_gamepad_reset_color/__input_gamepad_reset_color.gml
+++ b/scripts/__input_gamepad_reset_color/__input_gamepad_reset_color.gml
@@ -5,7 +5,7 @@ function __input_gamepad_reset_color(_gamepad_index)
     
     if (_gamepad_index < 0) return;
     
-    with (_global.__gamepads[_gamepad_index])
+    with(_global.__gamepads[_gamepad_index])
     {
         __color_set(undefined);
     }

--- a/scripts/__input_gamepad_set_mapping/__input_gamepad_set_mapping.gml
+++ b/scripts/__input_gamepad_set_mapping/__input_gamepad_set_mapping.gml
@@ -254,20 +254,20 @@ function __input_gamepad_set_mapping()
         var _mapping_lt = set_mapping(gp_shoulderlb, __XINPUT_AXIS_LT, __INPUT_MAPPING.AXIS, "lefttrigger");
         var _mapping_rt = set_mapping(gp_shoulderrb, __XINPUT_AXIS_RT, __INPUT_MAPPING.AXIS, "righttrigger");
         
+        //Scale trigger axes. Recalibrated later if value falls outside range
         if (is_numeric(__steam_handle))
         {
-            //Typical XInput scale (0 to 255/256)
-            _mapping_lt.scale = 255;
-            _mapping_rt.scale = 255;
+            //Scale per "Normal" XInput offset
+            __xinput_trigger_range = 255/256;
         }
         else
         {
-            //Scale per Xbox One and Series controllers over USB (0 to 63/256)
-            //Scale is recalibrated later if values fall outside of this range
-            _mapping_lt.scale = 63;
-            _mapping_rt.scale = 63;
-            scale_trigger = true;
+            //Scale per Xbox One/Series controllers over USB
+            __xinput_trigger_range = 63/256;
         }
+
+        _mapping_lt.scale = 1/__xinput_trigger_range;
+        _mapping_rt.scale = 1/__xinput_trigger_range;
         
         return;
     }
@@ -356,7 +356,7 @@ function __input_gamepad_set_mapping()
         set_mapping(gp_axislv, 1, __INPUT_MAPPING.AXIS, "lefty");
           
         //Set default mapping with digital triggers, test later
-        test_trigger = true;
+        __stadia_trigger_test = true;
             
         set_mapping(gp_shoulderrb, 11, __INPUT_MAPPING.BUTTON, "righttrigger");
         set_mapping(gp_shoulderlb, 12, __INPUT_MAPPING.BUTTON, "lefttrigger");

--- a/scripts/__input_gamepad_set_type/__input_gamepad_set_type.gml
+++ b/scripts/__input_gamepad_set_type/__input_gamepad_set_type.gml
@@ -418,7 +418,7 @@ function __input_gamepad_set_type()
                                 //Found IMU                                
                                 var _imu_index = _g;
                                 if (!__INPUT_SILENT) __input_trace("Overriding controller ", _imu_index ," type to \"HIDWiiRemoteIMU\"");
-                                with (_global.__gamepads[@ _imu_index])
+                                with(_global.__gamepads[@ _imu_index])
                                 {
                                     raw_type = "HIDWiiRemoteIMU";
                                     guessed_type = true;
@@ -427,7 +427,7 @@ function __input_gamepad_set_type()
                                 }
                             
                                 if (!__INPUT_SILENT) __input_trace("Overriding controller ", _ir_index ," type to \"HIDWiiRemoteIRSensor\"");
-                                with (_global.__gamepads[@ _ir_index])
+                                with(_global.__gamepads[@ _ir_index])
                                 {
                                     raw_type = "HIDWiiRemoteIRSensor";
                                     guessed_type = true;

--- a/scripts/__input_gamepad_stop_trigger_effects/__input_gamepad_stop_trigger_effects.gml
+++ b/scripts/__input_gamepad_stop_trigger_effects/__input_gamepad_stop_trigger_effects.gml
@@ -17,7 +17,7 @@ function __input_gamepad_stop_trigger_effects(_gamepad_index)
     
     if (_gamepad_index < 0) return;
     
-    with (_global.__gamepads[_gamepad_index])
+    with(_global.__gamepads[_gamepad_index])
     {
         __trigger_effect_apply(gp_shoulderlb, new __input_class_trigger_effect_off());
         __trigger_effect_apply(gp_shoulderrb, new __input_class_trigger_effect_off());

--- a/scripts/__input_hotswap_tick/__input_hotswap_tick.gml
+++ b/scripts/__input_hotswap_tick/__input_hotswap_tick.gml
@@ -46,7 +46,6 @@ function __input_hotswap_tick_input()
 {
     __INPUT_GLOBAL_STATIC_LOCAL  //Set static _global
     
-    //Check gamepad input before keyboard input to correctly handle Android duplicating button presses with keyboard presses
     if (_global.__any_gamepad_binding_defined)
     {
         //In-use gamepad
@@ -92,7 +91,7 @@ function __input_hotswap_tick_input()
     
     if (_global.__keyboard_allowed && _global.__any_keyboard_binding_defined
     &&  input_source_is_available(INPUT_KEYBOARD)
-    &&  keyboard_check(vk_anykey)
+    &&  keyboard_check_pressed(vk_anykey)
     &&  (__input_keyboard_key() > 0) //Ensure that the key is in the recognized range
     &&  !__input_key_is_ignored(__input_keyboard_key())) //Ensure that this key isn't one we're trying to ignore
     {

--- a/scripts/__input_initialize/__input_initialize.gml
+++ b/scripts/__input_initialize/__input_initialize.gml
@@ -728,6 +728,11 @@ function __input_initialize()
             input_ignore_key_add(0xE6); //OEM key (Power button on Steam Deck)
         }
         
+        if (__INPUT_ON_ANDROID)
+        {
+            input_ignore_key_add(vk_backspace); //Emmitted by hard and soft "Back" buttons, gamepad "B" button
+        }
+        
         if (INPUT_ON_MOBILE && __INPUT_ON_APPLE)
         {
             input_ignore_key_add(124); //Screenshot

--- a/scripts/__input_system_tick/__input_system_tick.gml
+++ b/scripts/__input_system_tick/__input_system_tick.gml
@@ -479,7 +479,8 @@ function __input_system_tick()
             var _gamepad = _global.__gamepads[_g];
             if (is_struct(_gamepad))
             {
-                if (gamepad_is_connected(_g))
+                var _connected = gamepad_is_connected(_g);
+                if (_connected)
                 {
                     with (_gamepad)
                     {
@@ -496,44 +497,33 @@ function __input_system_tick()
                                 virtual_set();
                                 led_set();
                             }
-                            
-                            tick();
-                            __disconnection_frame = undefined;
                         }
                     }
                 }
-                else
+                
+                var _sustain_connection = _gamepad.tick(_connected);
+                if not (_sustain_connection)
                 {
-                    //Timeout disconnection to prevent thrashing
-                    if (_gamepad.__disconnection_frame == undefined)
-                    {
-                        _gamepad.__disconnection_frame = _global.__frame;
-                    }
-                    
-                    if (_global.__frame - _gamepad.__disconnection_frame < __INPUT_GAMEPADS_DISCONNECTION_TIMEOUT)
-                    {
-                        _gamepad.tick();
-                    }
-                    else
-                    {                        
-                        //Remove our gamepad handler
-                        if (!__INPUT_SILENT) __input_trace("Gamepad ", _g, " disconnected");
+                    //Remove our gamepad handler
+                    if (!__INPUT_SILENT) __input_trace("Gamepad ", _g, " disconnected");
                         
-                        gamepad_set_vibration(_global.__gamepads[_g].index, 0, 0);
-                        _global.__gamepads[@ _g] = undefined;
+                    gamepad_set_vibration(_global.__gamepads[_g].index, 0, 0);
+                    _global.__gamepads[@ _g] = undefined;
                         
-                        //Also report gamepad changes for any active players
-                        var _p = 0;
-                        repeat(INPUT_MAX_PLAYERS)
+                    //Also report gamepad changes for any active players
+                    var _p = 0;
+                    repeat(INPUT_MAX_PLAYERS)
+                    {
+                        with(_global.__players[_p])
                         {
-                            with(_global.__players[_p])
+                            if (__source_contains(INPUT_GAMEPAD[_g]))
                             {
                                 __input_trace("Player ", _p, " gamepad disconnected");
                                 __source_remove(INPUT_GAMEPAD[_g]);
                             }
-                        
-                            ++_p;
                         }
+                        
+                        ++_p;
                     }
                 }
             }


### PR DESCRIPTION
- Hotswap to keyboard on press instead of check
- Newer delta approach negates Android input conflict fix, so block Back key explicitly
- Support incoming YYG reported XInput axis corrections
- Clean up some whitespace

Additionally some corrections to #805
  - Don't remove unassigned gamepad sources from player
  - Move disconnection internals into gamepad class
