### PR TITLE
added feather comments to input checker functions

### DIFF
--- a/scripts/input_check/input_check.gml
+++ b/scripts/input_check/input_check.gml
@@ -3,7 +3,7 @@
 ///          If the keyword <all> is used then this function will return <true> if ANY verb whatsoever is active
 ///          If an array of verbs is given then this function will return <true> if ANY of the verbs in the array are active
 ///          If a buffer duration is specified then this function will return <true> if the verb has been active at any point within that timeframe
-/// @param   verb/array
+/// @param   {String|Array<String>} verb/array
 /// @param   [playerIndex=0]
 /// @param   [bufferDuration=0]
 

--- a/scripts/input_check_double/input_check_double.gml
+++ b/scripts/input_check_double/input_check_double.gml
@@ -3,7 +3,7 @@
 ///          The double tap threshold is defined by INPUT_DOUBLE_DELAY
 ///          If an array of verbs is given then this function will return <true> if ANY verb has been doubled-tapped and held
 ///          If a buffer duration is specified then this function will return <true> if the verb has been double-tapped and held at any point within that timeframe
-/// @param   verb/array
+/// @param   {String|Array<String>} verb/array
 /// @param   [playerIndex=0]
 /// @param   [bufferDuration=0]
 

--- a/scripts/input_check_double_pressed/input_check_double_pressed.gml
+++ b/scripts/input_check_double_pressed/input_check_double_pressed.gml
@@ -2,7 +2,7 @@
 /// @desc    Returns a boolean indicating whether the given verb has been double-tapped this frame
 ///          If an array of verbs is given then this function will return <true> if ANY verb has been doubled-tapped this frame
 ///          If a buffer duration is specified then this function will return <true> if the verb has been double-tapped at any point within that timeframe
-/// @param   verb/array
+/// @param   {String|Array<String>} verb/array
 /// @param   [playerIndex=0]
 /// @param   [bufferDuration=0]
 

--- a/scripts/input_check_double_released/input_check_double_released.gml
+++ b/scripts/input_check_double_released/input_check_double_released.gml
@@ -2,7 +2,7 @@
 /// @desc    Returns a boolean indicating whether the given verb had been double-tapped and was deactivated this frame
 ///          If an array of verbs is given then this function will return <true> if ANY verb was double-tapped and then deactivated this frame
 ///          If a buffer duration is specified then this function will return <true> if the verb double-tapped and then deactivated at any point within that timeframe
-/// @param   verb/array
+/// @param   {String|Array<String>} verb/array
 /// @param   [playerIndex=0]
 /// @param   [bufferDuration=0]
 

--- a/scripts/input_check_long/input_check_long.gml
+++ b/scripts/input_check_long/input_check_long.gml
@@ -3,7 +3,7 @@
 ///          The long-hold threshold is defined by INPUT_LONG_DELAY
 ///          If an array of verbs is given then this function will return <true> if ANY verb has been active for a long time
 ///          If a buffer duration is specified then this function will return <true> if the verb has been active for a long time at any point within that timeframe
-/// @param   verb/array
+/// @param   {String|Array<String>} verb/array
 /// @param   [playerIndex=0]
 /// @param   [bufferDuration=0]
 

--- a/scripts/input_check_long_pressed/input_check_long_pressed.gml
+++ b/scripts/input_check_long_pressed/input_check_long_pressed.gml
@@ -3,7 +3,7 @@
 ///          The long-hold threshold is defined by INPUT_LONG_DELAY
 ///          If an array of verbs is given then this function will return <true> if ANY verb has crossed the long-hold threshold this frame
 ///          If a buffer duration is specified then this function will return <true> if the verb has crossed the long-hold threshold at any point within that timeframe
-/// @param   verb/array
+/// @param   {String|Array<String>} verb/array
 /// @param   [playerIndex=0]
 /// @param   [bufferDuration=0]
 

--- a/scripts/input_check_long_released/input_check_long_released.gml
+++ b/scripts/input_check_long_released/input_check_long_released.gml
@@ -3,7 +3,7 @@
 ///          The long-hold threshold is defined by INPUT_LONG_DELAY
 ///          If an array of verbs is given then this function will return <true> if ANY verb has been active for a long time and then deactivated
 ///          If a buffer duration is specified then this function will return <true> if the verb has been active for a long time and then deactivated at any point within that timeframe
-/// @param   verb/array
+/// @param   {String|Array<String>} verb/array
 /// @param   [playerIndex=0]
 /// @param   [bufferDuration=0]
 

--- a/scripts/input_check_pressed/input_check_pressed.gml
+++ b/scripts/input_check_pressed/input_check_pressed.gml
@@ -3,7 +3,7 @@
 ///          If the keyword <all> is used then this function will return <true> if ANY verb whatsoever was newly activated
 ///          If an array of verbs is given then this function will return <true> if ANY of the verbs in the array were newly activated
 ///          If a buffer duration is specified then this function will return <true> if the verb has been newly active at any point within that timeframe
-/// @param   verb/array
+/// @param   {String|Array<String>} verb/array
 /// @param   [playerIndex=0]
 /// @param   [bufferDuration=0]
 

--- a/scripts/input_check_quick_pressed/input_check_quick_pressed.gml
+++ b/scripts/input_check_quick_pressed/input_check_quick_pressed.gml
@@ -3,7 +3,7 @@
 ///          Behaviour of this function can be customised using the INPUT_QUICK_BUFFER macro
 ///          If an array of verbs is given then this function will return <true> if ANY verb has crossed the long-hold threshold this frame
 ///          If a buffer duration is specified then this function will return <true> if the verb has crossed the long-hold threshold at any point within that timeframe
-/// @param   verb/array
+/// @param   {String|Array<String>} verb/array
 /// @param   [playerIndex=0]
 /// @param   [bufferDuration=0]
 

--- a/scripts/input_check_released/input_check_released.gml
+++ b/scripts/input_check_released/input_check_released.gml
@@ -3,7 +3,7 @@
 ///          If the keyword <all> is used then this function will return <true> if ANY verb whatsoever was newly deactivated
 ///          If an array of verbs is given then this function will return <true> if ANY of the verbs in the array were newly deactivated
 ///          If a buffer duration is specified then this function will return <true> if the verb has been newly deactive at any point within that timeframe
-/// @param   verb/array
+/// @param   {String|Array<String>} verb/array
 /// @param   [playerIndex=0]
 /// @param   [bufferDuration=0]
 

--- a/scripts/input_held_time/input_held_time.gml
+++ b/scripts/input_held_time/input_held_time.gml
@@ -2,7 +2,7 @@
 /// @desc    Returns how long the current verb has been held for, the units of which is determined by INPUT_TIMER_MILLISECONDS
 ///          This function returns 0 if the verb has been activated on the current frame
 ///          It will return a value less than 0 if the verb is not active at all
-/// @param   verb/array
+/// @param   {String|Array<String>} verb/array
 /// @param   [playerIndex=0]
 
 function input_held_time(_verb, _player_index = 0)

--- a/scripts/input_held_time_released/input_held_time_released.gml
+++ b/scripts/input_held_time_released/input_held_time_released.gml
@@ -1,7 +1,7 @@
 // Feather disable all
 /// @desc    Returns how long the current verb was held when released, the units of which is determined by INPUT_TIMER_MILLISECONDS
 ///          This function returns a value less than 0 if the verb is not active or was not released
-/// @param   verb/array
+/// @param   {String|Array<String>} verb/array
 /// @param   [playerIndex=0]
 
 function input_held_time_released(_verb, _player_index = 0)

--- a/scripts/input_is_analogue/input_is_analogue.gml
+++ b/scripts/input_is_analogue/input_is_analogue.gml
@@ -1,7 +1,7 @@
 // Feather disable all
 /// @desc    Returns whether the given verb is currently received analogue input (e.g. from a gamepad thumbstick)
 ///          If an array of verbs is provided, this function will return <true> if ANY of the verbs have analogue input
-/// @param   verb/array
+/// @param   {String|Array<String>} verb/array
 /// @param   [playerIndex=0]
 
 function input_is_analogue(_verb, _player_index = 0)

--- a/scripts/input_max_value/input_max_value.gml
+++ b/scripts/input_max_value/input_max_value.gml
@@ -2,7 +2,7 @@
 /// @desc    Returns the maximum analogue value that the verb has received since it was pressed
 ///          If the verb has not received analogue input, this function will return either 0 or 1
 ///          If an array of verbs is provided, this function will return the sum of all verb values
-/// @param   verb/array
+/// @param   {String|Array<String>} verb/array
 /// @param   [playerIndex=0]
 
 function input_max_value(_verb, _player_index = 0)

--- a/scripts/input_value/input_value.gml
+++ b/scripts/input_value/input_value.gml
@@ -2,7 +2,7 @@
 /// @desc    Returns the analogue value that the verb is currently receiving
 ///          If the verb has not received analogue input, this function will return either 0 or 1
 ///          If an array of verbs is provided, this function will return the sum of all verb values
-/// @param   verb/array
+/// @param   {String|Array<String>} verb/array
 /// @param   [playerIndex=0]
 
 function input_value(_verb, _player_index = 0)

--- a/scripts/input_verb_consume/input_verb_consume.gml
+++ b/scripts/input_verb_consume/input_verb_consume.gml
@@ -2,7 +2,7 @@
 /// @desc    Deactivates a verb until the button (or other physical input) is released and pressed again
 ///          If an array of verbs is given then this function will consume all verbs in the array
 ///          If the keyword <all> is used then all exant verbs are consumed
-/// @param   verb/array
+/// @param   {String|Array<String>} verb/array
 /// @param   [playerIndex]
 
 function input_verb_consume(_verb, _player_index = 0)


### PR DESCRIPTION
same as i did for scribble: https://github.com/JujuAdams/Scribble/pull/500 because i grow tired of feather complaining that the verb being checked isn't the keyword `all`