### PR TITLE
Fixing Vbutton 1-frame delay

### DIFF
--- a/scripts/__input_class_combo_state/__input_class_combo_state.gml
+++ b/scripts/__input_class_combo_state/__input_class_combo_state.gml
@@ -175,10 +175,16 @@ function __input_class_combo_state(_name, _combo_def) constructor
     {
         if (__charge_measure)
         {
-            __remove_from_require_hold_array(_phase_array[__phase-1].__verb);
-            
             //Stop measuring the length of the charge
-            if (_reset_charge) __charge_measure = false;
+            if (_reset_charge) 
+			{
+				__charge_measure = false;
+			}
+			else
+			{
+				//Remove hold requirement when charge isn't reset
+				__remove_from_require_hold_array(_phase_array[__phase].__verb);
+			}
         }
         
         //Allow retriggering of a charge phase if that's the next type we're going to evaluate

--- a/scripts/__input_system_tick/__input_system_tick.gml
+++ b/scripts/__input_system_tick/__input_system_tick.gml
@@ -554,21 +554,8 @@ function __input_system_tick()
     
     #endregion
     
-    
-    
-    #region Players
-    
-    var _p = 0;
-    repeat(INPUT_MAX_PLAYERS)
-    {
-        _global.__players[_p].tick();
-        ++_p;
-    }
-    
-    #endregion
-    
-    
-    
+   
+   
     #region Virtual Buttons
     
     //Reorder virtual buttons if necessary, from highest priority to lowest
@@ -621,6 +608,19 @@ function __input_system_tick()
             _global.__virtual_array[_i].__tick();
             ++_i;
         }
+    }
+    
+    #endregion
+	
+	
+	
+    #region Players
+    
+    var _p = 0;
+    repeat(INPUT_MAX_PLAYERS)
+    {
+        _global.__players[_p].tick();
+        ++_p;
     }
     
     #endregion


### PR DESCRIPTION
Relocating Vbutton tick to be above player tick to fix 1-frame delay response in Vbutton verbs