### PR TITLE
Vbutton 1-frame delay fix

### DIFF
--- a/scripts/__input_system_tick/__input_system_tick.gml
+++ b/scripts/__input_system_tick/__input_system_tick.gml
@@ -555,20 +555,7 @@ function __input_system_tick()
     #endregion
     
     
-    
-    #region Players
-    
-    var _p = 0;
-    repeat(INPUT_MAX_PLAYERS)
-    {
-        _global.__players[_p].tick();
-        ++_p;
-    }
-    
-    #endregion
-    
-    
-    
+
     #region Virtual Buttons
     
     //Reorder virtual buttons if necessary, from highest priority to lowest
@@ -621,6 +608,19 @@ function __input_system_tick()
             _global.__virtual_array[_i].__tick();
             ++_i;
         }
+    }
+    
+    #endregion
+    
+    
+    
+    #region Players
+    
+    var _p = 0;
+    repeat(INPUT_MAX_PLAYERS)
+    {
+        _global.__players[_p].tick();
+        ++_p;
     }
     
     #endregion


### PR DESCRIPTION
Relocating Vbutton tick to be above player tick to fix 1-frame delay response in Vbutton verbs
