### PR TITLE
Fix for chord state not being recorded and crashing game.

### DIFF
--- a/scripts/__input_class_player/__input_class_player.gml
+++ b/scripts/__input_class_player/__input_class_player.gml
@@ -914,7 +914,22 @@ function __input_class_player() constructor
             __combo_state_dict[$ _verb_name] = new __input_class_combo_state(_verb_name, _combo_defintion);
         }
     }
-    
+
+    /// @param verbName
+    /// @param chordDefinition
+    static __add_chord_state = function(_verb_name, _chord_defintion)
+    {
+        //Set up a verb container on the player separate from the bindings
+        if (is_struct(__chord_state_dict[$ _verb_name]))
+        {
+            __input_error("Chord state with name \"", _verb_name, "\" has already been added to player ", __index);
+        }
+        else
+        {
+            __chord_state_dict[$ _verb_name] = new __input_class_chord_state(_verb_name, _chord_defintion);
+        }
+    }	
+
     #endregion
     
     

--- a/scripts/input_chord_create/input_chord_create.gml
+++ b/scripts/input_chord_create/input_chord_create.gml
@@ -36,7 +36,12 @@ function input_chord_create(_name, _max_time = INPUT_CHORD_DEFAULT_TIME)
     var _p = 0;
     repeat(INPUT_MAX_PLAYERS)
     {
-        _global.__players[_p].__add_complex_verb(_name, __INPUT_VERB_TYPE.__CHORD);
+        with(_global.__players[_p])
+        {
+            __add_chord_state(_name, _chord_definition);
+            __add_complex_verb(_name, __INPUT_VERB_TYPE.__CHORD);
+        }
+        
         ++_p;
     }
 }


### PR DESCRIPTION
Chord states weren't being added to the global `__chord_state_dict` being evaluated in the player tick.  Would cause a crash by simply creating any chord.  