### PR TITLE
Momentary vbuttons

### DIFF
--- a/objects/obj_test_virtual_buttons/Create_0.gml
+++ b/objects/obj_test_virtual_buttons/Create_0.gml
@@ -42,6 +42,7 @@ h = input_virtual_create()
 // Momentary button for button-mashing on a touchscreen
 i = input_virtual_create()
     .rectangle(900, 50, 1250, 300)
+    .button("accept")
     .momentary(true);
 
 test_x = room_width / 2;
@@ -57,9 +58,8 @@ type_str[$ INPUT_VIRTUAL_TYPE.DPAD_VERTICAL] = "DPAD Vertical";
 type_str[$ INPUT_VIRTUAL_TYPE.THUMBSTICK] = "Thumbstick";
 type_str[$ INPUT_VIRTUAL_TYPE.TOUCHPAD] = "Touchpad";
 pressed_vbutton_type = function() {
-    static _vbutton_arr = [a, b, c, d, e, f, g, h];
+    static _vbutton_arr = [a, b, c, d, e, f, g, h, i];
     static _len = array_length(_vbutton_arr);
-    var _type = undefined;
     for(var _i = 0; _i<_len; _i++) {
         if(_vbutton_arr[_i].check()) {
             return type_str[$ _vbutton_arr[_i].get_type()] ?? "";

--- a/objects/obj_test_virtual_buttons/Create_0.gml
+++ b/objects/obj_test_virtual_buttons/Create_0.gml
@@ -39,6 +39,11 @@ h = input_virtual_create()
     .dpad(undefined, "left", "right", "up", "down", false)
     .active(true);
 
+// Momentary button for button-mashing on a touchscreen
+i = input_virtual_create()
+    .rectangle(900, 50, 1250, 300)
+    .momentary(true);
+
 test_x = room_width / 2;
 test_y = room_height / 2;
 

--- a/objects/obj_test_virtual_buttons/Draw_64.gml
+++ b/objects/obj_test_virtual_buttons/Draw_64.gml
@@ -3,12 +3,13 @@
 input_virtual_debug_draw();
 
 var _string = concat(
-    "accept = ", input_value("accept"), ", check = ", input_check("accept"), "\n",
-    "right  = ", input_value("right" ), ", check = ", input_check("right" ), "\n",
-    "up     = ", input_value("up"    ), ", check = ", input_check("up"    ), "\n",
-    "left   = ", input_value("left"  ), ", check = ", input_check("left"  ), "\n",
-    "down   = ", input_value("down"  ), ", check = ", input_check("down"  ), "\n",
-    "type   = ", pressed_vbutton_type(), "\n"
+    "accept    = ", input_value("accept"), ", check = ", input_check("accept"), "\n",
+    "right     = ", input_value("right" ), ", check = ", input_check("right" ), "\n",
+    "up        = ", input_value("up"    ), ", check = ", input_check("up"    ), "\n",
+    "left      = ", input_value("left"  ), ", check = ", input_check("left"  ), "\n",
+    "down      = ", input_value("down"  ), ", check = ", input_check("down"  ), "\n",
+    "type      = ", pressed_vbutton_type(), "\n",
+    "momentary = ", i.get_momentary()? "ON\n" : "off\n",
 );
 
 var _func_draw_arrow = function(_x1, _y1, _x2, _y2)

--- a/objects/obj_test_virtual_buttons/Step_0.gml
+++ b/objects/obj_test_virtual_buttons/Step_0.gml
@@ -6,6 +6,11 @@ if (input_check_pressed("accept"))
     c.active(!c.get_active());
 }
 
+if (a.pressed())
+{
+    i.momentary(!i.get_momentary());
+}
+
 //test_x += 6*input_check_opposing("left", "right");
 //test_y += 6*input_check_opposing("up", "down");
 

--- a/scripts/__input_class_virtual/__input_class_virtual.gml
+++ b/scripts/__input_class_virtual/__input_class_virtual.gml
@@ -35,8 +35,6 @@ function __input_class_virtual() constructor
     __verb_down    = undefined;
     __max_distance = 1;
     
-    __4dir = false;
-    
     __threshold_min = INPUT_VIRTUAL_BUTTON_MIN_THRESHOLD;
     __threshold_max = INPUT_VIRTUAL_BUTTON_MAX_THRESHOLD;
     
@@ -46,6 +44,7 @@ function __input_class_virtual() constructor
     __follow           = false;
     __record_history   = false;
     __first_touch_only = false;
+    __momentary        = false;
     
     //State
     //These variables should be cleared by .__clear_state()
@@ -406,6 +405,18 @@ function __input_class_virtual() constructor
     static get_reference_point = function()
     {
         return __reference;
+    }
+    
+    static momentary = function(_state)
+    {
+        __momentary = _state;
+        
+        return self;
+    }
+    
+    static get_momentary = function()
+    {
+        return __momentary;
     }
     
     #endregion
@@ -770,7 +781,7 @@ function __input_class_virtual() constructor
         }
         else
         {
-            var _sustain = device_mouse_check_button(__touch_device, mb_left);          
+            var _sustain = __momentary? (__capture_frame == __global.__frame) : device_mouse_check_button(__touch_device, mb_left);          
             
             //Guard iOS dropping a sustained hold on SystemGestureGate timeout
             if (__INPUT_ON_IOS)


### PR DESCRIPTION
Virtual buttons have a habit of missing touch inputs if a button is rapidly tapped by two different fingers e.g. for a button-mashing minigame. This is due to buttons (justifiably) blocking retriggering by a subsequent touchpoint until the current touchpoint has been fully released. Touchpoint release appears to be slightly delayed at the hardware/OS level on the touchscreens I've tested which means the second press event is being ignored if triggered too early.

This PR adds a "momentary" mode to virtual buttons that causes the button to emit a press event on the frame the button is tapped, and then emit a release event on the very next frame. The internal touchpoint tracking for the button is cleared on the release event enabling the button to be retriggered when another touchpoint is pressed.

Momentary behaviour can be toggled by calling the `.momentary()` method on a virtual button and can be returned via `.get_momentary()`. Buttons default to non-momentary.