### PR TITLE
Update README.md to link-back InputCandy

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@
 - ### [Download the .yymps](https://github.com/JujuAdams/input/releases/)
 - ### Read the [documentation](https://offalynne.github.io/Input/)
 - ### Talk about Input on the [Discord server](https://discord.gg/RDYyRqBswD)
-- ### You may also like [Firehammer](https://firehammergames.itch.io/firehammer-input) and [Input Dog](https://github.com/messhof/Input-Dog)
+- ### You may also like [InputCandy](https://github.com/LAGameStudio/InputCandy], [Firehammer](https://firehammergames.itch.io/firehammer-input) and [Input Dog](https://github.com/messhof/Input-Dog)


### PR DESCRIPTION
InputCandy originally linked to Jujuadams' Input library back when it was first established.  We were told we'd get a link back, why didn't we?