### PR TITLE
Fix 2024.2 crash

### DIFF
--- a/scripts/__input_macros/__input_macros.gml
+++ b/scripts/__input_macros/__input_macros.gml
@@ -8,8 +8,6 @@
 
 #region Forbidden Fruit
 
-#macro __INPUT_2D_CHECKER_STATIC_RESULT  true
-
 #macro __INPUT_DEBUG_PROFILES  false
 #macro __INPUT_DEBUG_SOURCES   false
 #macro __INPUT_DEBUG_BINDING   false

--- a/scripts/input_xy/input_xy.gml
+++ b/scripts/input_xy/input_xy.gml
@@ -9,20 +9,10 @@
 
 function input_xy(_verb_l, _verb_r, _verb_u, _verb_d, _player_index = 0, _most_recent = INPUT_DEFAULT_2D_MOST_RECENT)
 {
-    if (__INPUT_2D_CHECKER_STATIC_RESULT)
-    {
-        static _result = {
-            x: 0,
-            y: 0,
-        };
-    }
-    else
-    {
-        var _result = {
-            x: 0,
-            y: 0,
-        };
-    }
+    static _result = {
+        x: 0,
+        y: 0,
+    };
     
     if (!is_struct(_player_index))
     {


### PR DESCRIPTION
static and local variable name overlap causes a crash in 2024.2 and newer, apparently intended behavior