### PR TITLE
CSS hack to fix scroll to anchor

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -384,6 +384,16 @@
 					opacity: 0.5;
 				}
 			}
+			
+			/* css hack to fix scroll to anchor in docsify tabs */
+			.docsify-tabs:not(:has(> button.docsify-tabs__tab--active))>.docsify-tabs__content[class]:nth-child(2) {
+				visibility: visible;
+				position: relative;
+				overflow: auto;
+				height: auto;
+
+				padding: var(--docsifytabs-content-padding);
+			}
 		</style>
 		<script>
 			/* Add word break opportunity after function opening parentheses */


### PR DESCRIPTION
as per https://github.com/jhildenbiddle/docsify-tabs/pull/61

This is a Docsify issue with not knowing the height of the docsify-tabs sections before it does the scrolling. It's been like 4 years and it hasn't been fixed yet so this hack will have to be it for now.