### PR TITLE
Swap ignore/allow structs for arrays in `InputDeviceSetRebinding()`

### DIFF
--- a/scripts/InputDeviceSetRebinding/InputDeviceSetRebinding.gml
+++ b/scripts/InputDeviceSetRebinding/InputDeviceSetRebinding.gml
@@ -3,7 +3,8 @@
 /// Sets rebinding state for a device. The device will be scanned for all input. Discovered
 /// bindings can be returned by calling `InputDeviceGetRebindingResult()`. Only gamepads and
 /// keyboard and mouse (`INPUT_KBM`) devices can be scanned. Bindings to explicitly ignore and
-/// allow can be set up by passing structs into the optional `ignoreStruct` and `allowStruct`.
+/// allow can be set up by passing arrays into the optional `ignoreArray` and `allowArray`
+/// parameters.
 /// 
 /// N.B. Input from a device that is being scanned will continue as normal. To prevent input
 ///      leaking to e.g. interface navigation you should be careful to check against
@@ -11,10 +12,10 @@
 /// 
 /// @param {Real} device
 /// @param {Bool} state
-/// @param {Bool} [ignoreStruct]
-/// @param {Bool} [allowStruct]
+/// @param {Bool} [ignoreArray]
+/// @param {Bool} [allowArray]
 
-function InputDeviceSetRebinding(_device, _state, _ignoreStruct = undefined, _allowStruct = undefined)
+function InputDeviceSetRebinding(_device, _state, _ignoreArray = undefined, _allowArray = undefined)
 {
     static _rebindingMap   = __InputSystem().__rebindingMap;
     static _rebindingArray = __InputSystem().__rebindingArray;
@@ -30,7 +31,7 @@ function InputDeviceSetRebinding(_device, _state, _ignoreStruct = undefined, _al
         {
             InputVerbConsumeAll(InputDeviceGetPlayer(_device));
             
-            var _handler = new __InputClassRebindingHandler(_device, _ignoreStruct, _allowStruct);
+            var _handler = new __InputClassRebindingHandler(_device, _ignoreArray, _allowArray);
             _rebindingMap[? _device] = _handler;
             array_push(_rebindingArray, _handler);
         }

--- a/scripts/__InputBindingScan/__InputBindingScan.gml
+++ b/scripts/__InputBindingScan/__InputBindingScan.gml
@@ -4,7 +4,7 @@ function __InputBindingScan(_device, _ignoreStruct, _allowStruct)
     
     static _funcFilter = function(_input, _ignoreStruct, _allowStruct) //Returns <false> if the binding failed to pass the filter
     {
-        if (is_struct(_ignoreStruct) && variable_struct_exists(_ignoreStruct, string(_input))) return false;
+        if (variable_struct_exists(_ignoreStruct, string(_input))) return false;
         if (is_struct(_allowStruct) && (not variable_struct_exists(_allowStruct, string(_input)))) return false;
         return true;
     }

--- a/scripts/__InputClassRebindingHandler/__InputClassRebindingHandler.gml
+++ b/scripts/__InputClassRebindingHandler/__InputClassRebindingHandler.gml
@@ -1,14 +1,82 @@
 // Feather disable all
 
 /// @param device
-/// @param ignoreStruct
-/// @param allowStruct
+/// @param ignoreArray
+/// @param allowArray
 
-function __InputClassRebindingHandler(_device, _ignoreStruct, _allowStruct) constructor
+function __InputClassRebindingHandler(_device, _ignoreArray, _allowArray) constructor
 {
     __device = _device;
     
     __createTime = current_time;
+    
+    //Convert ignore array into a struct for faster look-up later
+    if (is_struct(_ignoreArray))
+    {
+        //Legacy support for 10.0.6 and older
+        var _ignoreStruct = _ignoreArray;
+    }
+    else if (is_undefined(_ignoreArray))
+    {
+        //Pass through an empty struct
+        var _ignoreStruct = {};
+    }
+    else if (not is_array(_ignoreArray))
+    {
+        __InputError($"Rebinding ignore data must be an array or `undefined` (was \"{typeof(_ignoreArray)}\")");
+    }
+    else
+    {
+        var _ignoreStruct = {};
+        var _i = 0;
+        repeat(array_length(_ignoreArray))
+        {
+            var _binding = _ignoreArray[_i];
+            
+            //Convert letters into bindings
+            if (is_string(_binding))
+            {
+                _binding = ord(_binding);
+            }
+            
+            _ignoreStruct[$ string(_binding)] = true;
+            ++_i;
+        }
+    }
+    
+    //Convert allow array into a struct for faster look-up later
+    if (is_struct(_allowArray))
+    {
+        //Legacy support for 10.0.6 and older
+        var _allowStruct = _allowArray;
+    }
+    else if (is_undefined(_allowArray))
+    {
+        //Pass through `undefined` to signify "anything goes"
+        var _allowStruct = undefined;
+    }
+    else if (not is_array(_allowArray))
+    {
+        __InputError($"Rebinding allow data must be an array or `undefined` (was \"{typeof(_allowArray)}\")");
+    }
+    else
+    {
+        var _allowStruct = {};
+        var _i = 0;
+        repeat(array_length(_allowArray))
+        {
+            var _binding = _allowArray[_i];
+            
+            //Convert letters into bindings
+            if (is_string(_binding))
+            {
+                _binding = ord(_binding);
+            }
+            
+            _allowStruct[$ string(_binding)] = true;
+            ++_i;
+        }
+    }
     
     __rebindingWait         = true;
     __rebindingResult       = undefined;


### PR DESCRIPTION
Using structs as the option ignore/allow parameters for `InputDeviceSetRebinding()` is manifestly horrid UX. This PR addresses the problem in a backwards compatible way by allowing arrays to be specified instead which are then converted to structs.