### PR TITLE
Fix infinite loop in `InputCheckMany()`

### DIFF
--- a/scripts/InputCheckMany/InputCheckMany.gml
+++ b/scripts/InputCheckMany/InputCheckMany.gml
@@ -28,7 +28,7 @@ function InputCheckMany(_verbIndexArray, _playerIndexArray = 0)
             var _p = 0;
             repeat(array_length(_playerIndexArray))
             {
-                if (InputCheckMany(_verbIndexArray, _playerIndexArray[_p])) return true;
+                if (InputCheck(_verbIndexArray, _playerIndexArray[_p])) return true;
                 ++_p;
             }
         }
@@ -37,13 +37,13 @@ function InputCheckMany(_verbIndexArray, _playerIndexArray = 0)
             var _playerIndex = 0;
             repeat(INPUT_MAX_PLAYERS)
             {
-                if (InputCheckMany(_verbIndexArray, _playerIndex)) return true;
+                if (InputCheck(_verbIndexArray, _playerIndex)) return true;
                 ++_playerIndex;
             }
         }
         else
         {
-            return InputCheckMany(_verbIndexArray, _playerIndexArray);
+            return InputCheck(_verbIndexArray, _playerIndexArray);
         }
     }
     


### PR DESCRIPTION
Fixes an infinite loop caused by `InputCheckMany()` using the wrong function for its exit conditions.
