### PR TITLE
Fixes crash on boot when verb indexes are discontinuous

### DIFF
--- a/scripts/InputBindingsExport/InputBindingsExport.gml
+++ b/scripts/InputBindingsExport/InputBindingsExport.gml
@@ -11,9 +11,8 @@
 
 function InputBindingsExport(_forGamepad, _playerIndex = 0)
 {
-    static _playerArray         = __InputSystemPlayerArray();
-    static _verbDefinitionArray = __InputSystem().__verbDefinitionArray;
-    static _verbCount           = __InputSystem().__verbCount;
+    static _playerArray = __InputSystemPlayerArray();
+    static _verbCount   = __InputSystem().__verbCount;
     
     var _output = {};
     

--- a/scripts/InputBindingsExport/InputBindingsExport.gml
+++ b/scripts/InputBindingsExport/InputBindingsExport.gml
@@ -21,7 +21,12 @@ function InputBindingsExport(_forGamepad, _playerIndex = 0)
     var _i = 0;
     repeat(_verbCount)
     {
-        _output[$ InputVerbGetExportName(_i)] = variable_clone(_bindingArray[_i]);
+        var _exportName = InputVerbGetExportName(_i);
+        if (_exportName != undefined)
+        {
+            _output[$ _exportName] = variable_clone(_bindingArray[_i]);
+        }
+        
         ++_i;
     }
     

--- a/scripts/InputBindingsImport/InputBindingsImport.gml
+++ b/scripts/InputBindingsImport/InputBindingsImport.gml
@@ -19,8 +19,13 @@ function InputBindingsImport(_forGamepad, _data, _playerIndex = 0)
     var _i = 0;
     repeat(_verbCount)
     {
-        var _alternates = _data[$ InputVerbGetExportName(_i)];
-        _bindingArray = (_alternates == undefined)? [] : variable_clone(_alternates);
+        var _exportName = InputVerbGetExportName(_i);
+        if (_exportName != undefined)
+        {
+            var _alternates = _data[$ _exportName];
+            _bindingArray = (_alternates == undefined)? [] : variable_clone(_alternates);
+        }
+        
         ++_i;
     }
 }

--- a/scripts/InputBindingsImport/InputBindingsImport.gml
+++ b/scripts/InputBindingsImport/InputBindingsImport.gml
@@ -11,9 +11,8 @@
 
 function InputBindingsImport(_forGamepad, _data, _playerIndex = 0)
 {
-    static _playerArray         = __InputSystemPlayerArray();
-    static _verbDefinitionArray = __InputSystem().__verbDefinitionArray;
-    static _verbCount           = __InputSystem().__verbCount;
+    static _playerArray = __InputSystemPlayerArray();
+    static _verbCount   = __InputSystem().__verbCount;
     
     var _bindingArray = _forGamepad? _playerArray[_playerIndex].__gamepadBindingArray : _playerArray[_playerIndex].__kbmBindingArray;
     var _i = 0;

--- a/scripts/InputBindingsReset/InputBindingsReset.gml
+++ b/scripts/InputBindingsReset/InputBindingsReset.gml
@@ -13,16 +13,18 @@ function InputBindingsReset(_forGamepad, _playerIndex = 0)
     {
         array_map_ext(_playerArray[_playerIndex].__gamepadBindingArray, function(_element, _index)
         {
-            static _verbArray = __InputSystem().__verbDefinitionArray;
-            return variable_clone(_verbArray[_index].__gamepadBinding);
+            static _verbDefinitionArray = __InputSystem().__verbDefinitionArray;
+            var _verbDefinition = _verbDefinitionArray[_index];
+            return (_verbDefinition != undefined)? variable_clone(_verbDefinition.__gamepadBinding) : [];
         });
     }
     else
     {
         array_map_ext(_playerArray[_playerIndex].__kbmBindingArray, function(_element, _index)
         {
-            static _verbArray = __InputSystem().__verbDefinitionArray;
-            return variable_clone(_verbArray[_index].__kbmBinding);
+            static _verbDefinitionArray = __InputSystem().__verbDefinitionArray;
+            var _verbDefinition = _verbDefinitionArray[_index];
+            return (_verbDefinition != undefined)? variable_clone(_verbDefinition.__kbmBinding) : [];
         });
     }
 }

--- a/scripts/__InputClassPlayer/__InputClassPlayer.gml
+++ b/scripts/__InputClassPlayer/__InputClassPlayer.gml
@@ -47,14 +47,16 @@ function __InputClassPlayer(_playerIndex) constructor
     
     __kbmBindingArray = array_create_ext(_verbCount, function(_index)
     {
-        static _verbArray = __InputSystem().__verbDefinitionArray;
-        return variable_clone(_verbArray[_index].__kbmBinding);
+        static _verbDefinitionArray = __InputSystem().__verbDefinitionArray;
+        var _verbDefinition = _verbDefinitionArray[_index];
+        return (_verbDefinition != undefined)? variable_clone(_verbDefinition.__kbmBinding) : [];
     });
     
     __gamepadBindingArray = array_create_ext(_verbCount, function(_index)
     {
-        static _verbArray = __InputSystem().__verbDefinitionArray;
-        return variable_clone(_verbArray[_index].__gamepadBinding);
+        static _verbDefinitionArray = __InputSystem().__verbDefinitionArray;
+        var _verbDefinition = _verbDefinitionArray[_index];
+        return (_verbDefinition != undefined)? variable_clone(_verbDefinition.__gamepadBinding) : [];
     });
     
     __verbStateArray = array_create_ext(_verbCount, function(_index)
@@ -65,13 +67,15 @@ function __InputClassPlayer(_playerIndex) constructor
     __verbMetadataArray = array_create_ext(_verbCount, function(_index)
     {
         static _verbDefinitionArray = __InputSystem().__verbDefinitionArray;
-        return variable_clone(_verbDefinitionArray[_index].__metadata);
+        var _verbDefinition = _verbDefinitionArray[_index];
+        return (_verbDefinition != undefined)? variable_clone(_verbDefinition.__metadata) : undefined;
     });
     
     __clusterMetadataArray = array_create_ext(_clusterCount, function(_index)
     {
         static _clusterDefinitionArray = __InputSystem().__clusterDefinitionArray;
-        return variable_clone(_clusterDefinitionArray[_index].__metadata);
+        var _clusterDefinition = _clusterDefinitionArray[_index];
+        return (_clusterDefinition != undefined)? variable_clone(_clusterDefinition.__metadata) : undefined;
     });
     
     __valueRawArray   = array_create(_verbCount, 0);
@@ -510,6 +514,12 @@ function __InputClassPlayer(_playerIndex) constructor
         repeat(_clusterCount)
         {
             var _clusterDefinition = _clusterDefinitionArray[_i];
+            
+            if (not is_struct(_clusterDefinition))
+            {
+                ++_i;
+                continue;
+            }
             
             //Pull raw verb values so we can apply thresholds in 2D
             var _valueU = _verbStateArray[_clusterDefinition.__verbUp   ].__valueRaw;


### PR DESCRIPTION
Whilst the verb definition system is set up to cope with discontinuous verb indexes in principle, in reality there is a crash on boot during player instantiation due to the presumption the definition array is always populated with structs.

This PR fixes the crash by handling `undefined` in the verb definition array in sensitive areas across the library.