### PR TITLE
Adds player index safety checks

### DIFF
--- a/scripts/InputBindingFind/InputBindingFind.gml
+++ b/scripts/InputBindingFind/InputBindingFind.gml
@@ -12,12 +12,14 @@
 
 function InputBindingFind(_forGamepad, _binding, _playerIndex = 0)
 {
-    static _verbCount = __InputSystem().__verbCount;
+    static _playerArray = __InputSystemPlayerArray();
+    static _verbCount   = __InputSystem().__verbCount;
     
     static _array = [];
     array_resize(_array, 0);
     
-    var _playerArray = __InputSystemPlayerArray();
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     with(_playerArray[_playerIndex])
     {
         var _bindingArray = _forGamepad? __gamepadBindingArray : __kbmBindingArray;

--- a/scripts/InputBindingGet/InputBindingGet.gml
+++ b/scripts/InputBindingGet/InputBindingGet.gml
@@ -11,7 +11,10 @@
 
 function InputBindingGet(_forGamepad, _verbIndex, _alternate = 0, _playerIndex = 0)
 {
-    var _playerArray = __InputSystemPlayerArray();
+    static _playerArray = __InputSystemPlayerArray();
+    
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     with(_playerArray[_playerIndex])
     {
         var _bindingArray = _forGamepad? __gamepadBindingArray : __kbmBindingArray;

--- a/scripts/InputBindingSet/InputBindingSet.gml
+++ b/scripts/InputBindingSet/InputBindingSet.gml
@@ -16,7 +16,10 @@
 
 function InputBindingSet(_forGamepad, _verbIndex, _binding, _alternate = 0, _playerIndex = 0)
 {
-    var _playerArray = __InputSystemPlayerArray();
+    static _playerArray = __InputSystemPlayerArray();
+    
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     with(_playerArray[_playerIndex])
     {
         var _bindingArray = _forGamepad? __gamepadBindingArray : __kbmBindingArray;

--- a/scripts/InputBindingSetSafe/InputBindingSetSafe.gml
+++ b/scripts/InputBindingSetSafe/InputBindingSetSafe.gml
@@ -17,7 +17,10 @@
 
 function InputBindingSetSafe(_forGamepad, _verbIndexA, _binding, _alternateA = 0, _playerIndex = 0)
 {
-    var _playerArray = __InputSystemPlayerArray();
+    static _playerArray = __InputSystemPlayerArray();
+    
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     with(_playerArray[_playerIndex])
     {
         var _collisions = InputBindingFind(_forGamepad, _binding, _playerIndex);

--- a/scripts/InputBindingSwap/InputBindingSwap.gml
+++ b/scripts/InputBindingSwap/InputBindingSwap.gml
@@ -11,6 +11,8 @@
 
 function InputBindingSwap(_forGamepad, _verbIndexA, _alternateA, _verbIndexB, _alternateB, _playerIndex = 0)
 {
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     var _bindingA = InputBindingGet(_forGamepad, _verbIndexA, _alternateA, _playerIndex);
     var _bindingB = InputBindingGet(_forGamepad, _verbIndexB, _alternateB, _playerIndex);
     InputBindingSet(_forGamepad, _verbIndexA, _bindingB, _alternateA, _playerIndex);

--- a/scripts/InputBindingsExport/InputBindingsExport.gml
+++ b/scripts/InputBindingsExport/InputBindingsExport.gml
@@ -14,6 +14,8 @@ function InputBindingsExport(_forGamepad, _playerIndex = 0)
     static _playerArray = __InputSystemPlayerArray();
     static _verbCount   = __InputSystem().__verbCount;
     
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     var _output = {};
     
     var _bindingArray = _forGamepad? _playerArray[_playerIndex].__gamepadBindingArray : _playerArray[_playerIndex].__kbmBindingArray;

--- a/scripts/InputBindingsImport/InputBindingsImport.gml
+++ b/scripts/InputBindingsImport/InputBindingsImport.gml
@@ -14,6 +14,8 @@ function InputBindingsImport(_forGamepad, _data, _playerIndex = 0)
     static _playerArray = __InputSystemPlayerArray();
     static _verbCount   = __InputSystem().__verbCount;
     
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     var _bindingArray = _forGamepad? _playerArray[_playerIndex].__gamepadBindingArray : _playerArray[_playerIndex].__kbmBindingArray;
     var _i = 0;
     repeat(_verbCount)

--- a/scripts/InputBindingsReset/InputBindingsReset.gml
+++ b/scripts/InputBindingsReset/InputBindingsReset.gml
@@ -9,6 +9,8 @@ function InputBindingsReset(_forGamepad, _playerIndex = 0)
 {
     static _playerArray = __InputSystemPlayerArray();
     
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     if (_forGamepad)
     {
         array_map_ext(_playerArray[_playerIndex].__gamepadBindingArray, function(_element, _index)

--- a/scripts/InputCheck/InputCheck.gml
+++ b/scripts/InputCheck/InputCheck.gml
@@ -10,5 +10,8 @@
 function InputCheck(_verbIndex, _playerIndex = 0)
 {
     static _playerArray = __InputSystemPlayerArray();
+    
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     return _playerArray[_playerIndex].__verbStateArray[_verbIndex].__held;
 }

--- a/scripts/InputClusterGetMetadata/InputClusterGetMetadata.gml
+++ b/scripts/InputClusterGetMetadata/InputClusterGetMetadata.gml
@@ -11,6 +11,9 @@
 function InputClusterGetMetadata(_cluster, _playerIndex = 0, _makeCopy = false)
 {
     static _playerArray = __InputSystemPlayerArray();
+    
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     var _data = _playerArray[_playerIndex].__clusterMetadataArray[_cluster];
     return _makeCopy? variable_clone(_data) : _data;
 }

--- a/scripts/InputClusterResetMetadata/InputClusterResetMetadata.gml
+++ b/scripts/InputClusterResetMetadata/InputClusterResetMetadata.gml
@@ -10,6 +10,8 @@ function InputClusterResetMetadata(_cluster, _playerIndex = 0)
     static _clusterDefinitionArray = __InputSystem().__clusterDefinitionArray;
     static _playerArray            = __InputSystemPlayerArray();
     
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     var _clusterMetadataArray = _playerArray[_playerIndex].__clusterMetadataArray;
     _clusterMetadataArray[@ _cluster] = variable_clone(_clusterDefinitionArray[_cluster].__metadata);
 }

--- a/scripts/InputClusterSetMetadata/InputClusterSetMetadata.gml
+++ b/scripts/InputClusterSetMetadata/InputClusterSetMetadata.gml
@@ -14,6 +14,8 @@ function InputClusterSetMetadata(_cluster, _data, _playerIndex = 0, _makeCopy = 
 {
     static _playerArray = __InputSystemPlayerArray();
     
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     var _clusterMetadataArray = _playerArray[_playerIndex].__clusterMetadataArray;
     _clusterMetadataArray[@ _cluster] = _makeCopy? variable_clone(_data) : _data;
 }

--- a/scripts/InputColorGet/InputColorGet.gml
+++ b/scripts/InputColorGet/InputColorGet.gml
@@ -8,6 +8,8 @@
 function InputColorGet(_playerIndex = 0)
 {
      static _playerArray = __InputColorSystem().__playerArray;
+    
+    __INPUT_VALIDATE_PLAYER_INDEX
      
      return _playerArray[_playerIndex].__color;
 }

--- a/scripts/InputColorReset/InputColorReset.gml
+++ b/scripts/InputColorReset/InputColorReset.gml
@@ -7,6 +7,8 @@
 function InputColorReset(_playerIndex = 0)
 {
      static _playerArray = __InputColorSystem().__playerArray;
+    
+    __INPUT_VALIDATE_PLAYER_INDEX
      
      _playerArray[_playerIndex].__SetColor(undefined);
 }

--- a/scripts/InputColorSet/InputColorSet.gml
+++ b/scripts/InputColorSet/InputColorSet.gml
@@ -9,6 +9,8 @@
 function InputColorSet(_color, _playerIndex = 0)
 {
      static _playerArray = __InputColorSystem().__playerArray;
+    
+    __INPUT_VALIDATE_PLAYER_INDEX
      
      _playerArray[_playerIndex].__SetColor(_color);
 }

--- a/scripts/InputColorSupportedByDevice/InputColorSupportedByDevice.gml
+++ b/scripts/InputColorSupportedByDevice/InputColorSupportedByDevice.gml
@@ -9,6 +9,8 @@
 function InputColorSupportedByDevice(_playerIndex = 0)
 {
      static _playerArray = __InputColorSystem().__playerArray;
+    
+    __INPUT_VALIDATE_PLAYER_INDEX
      
      return _playerArray[_playerIndex].__SupportedByDevice();
 }

--- a/scripts/InputDeviceCheckViaPlayer/InputDeviceCheckViaPlayer.gml
+++ b/scripts/InputDeviceCheckViaPlayer/InputDeviceCheckViaPlayer.gml
@@ -10,6 +10,8 @@ function InputDeviceCheckViaPlayer(_device, _verbIndex, _playerIndex = 0)
 {
     static _playerArray = __InputSystemPlayerArray();
     
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     with(_playerArray[_playerIndex])
     {
         if (_device >= 0)

--- a/scripts/InputDeviceGetNewActivityOnVerb/InputDeviceGetNewActivityOnVerb.gml
+++ b/scripts/InputDeviceGetNewActivityOnVerb/InputDeviceGetNewActivityOnVerb.gml
@@ -8,6 +8,8 @@
 
 function InputDeviceGetNewActivityOnVerb(_verbIndex, _playerIndex = 0)
 {
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     var _array = InputDeviceEnumerate(false);
     var _i = 0;
     repeat(array_length(_array))

--- a/scripts/InputDirection/InputDirection.gml
+++ b/scripts/InputDirection/InputDirection.gml
@@ -9,6 +9,9 @@
 function InputDirection(_default, _clusterIndex, _playerIndex = 0)
 {
     static _playerArray = __InputSystemPlayerArray();
+    
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     with(_playerArray[_playerIndex])
     {
         var _x = __clusterXArray[_clusterIndex];

--- a/scripts/InputDistance/InputDistance.gml
+++ b/scripts/InputDistance/InputDistance.gml
@@ -8,6 +8,9 @@
 function InputDistance(_clusterIndex, _playerIndex = 0)
 {
     static _playerArray = __InputSystemPlayerArray();
+    
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     with(_playerArray[_playerIndex])
     {
         return point_distance(0, 0, __clusterXArray[_clusterIndex], __clusterYArray[_clusterIndex]);

--- a/scripts/InputDuration/InputDuration.gml
+++ b/scripts/InputDuration/InputDuration.gml
@@ -12,6 +12,8 @@ function InputDuration(_verbIndex, _playerIndex = 0)
     static _system      = __InputSystem();
     static _playerArray = __InputSystemPlayerArray();
     
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     with(_playerArray[_playerIndex].__verbStateArray[_verbIndex])
     {
         return (_system.__frame - __pressFrame);

--- a/scripts/InputIconGet/InputIconGet.gml
+++ b/scripts/InputIconGet/InputIconGet.gml
@@ -10,6 +10,8 @@
 
 function InputIconGet(_verbIndex, _alternate = 0, _playerIndex = 0)
 {
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     var _forGamepad = InputPlayerUsingGamepad(_playerIndex);
     return InputIconGetDirect(InputBindingGet(_forGamepad, _verbIndex, _alternate, _playerIndex),
                                  _forGamepad,

--- a/scripts/InputLast/InputLast.gml
+++ b/scripts/InputLast/InputLast.gml
@@ -14,6 +14,8 @@ function InputLast(_verbIndexArray = -1, _playerIndex = 0)
     static _playerArray       = __InputSystemPlayerArray();
     static _verbDefIndexArray = _system.__verbDefIndexArray;
     
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     //Convert `-1` to the array of all verb definitions
     if (is_numeric(_verbIndexArray) && (_verbIndexArray == -1))
     {

--- a/scripts/InputLong/InputLong.gml
+++ b/scripts/InputLong/InputLong.gml
@@ -12,6 +12,8 @@ function InputLong(_verbIndex, _playerIndex = 0, _duration = INPUT_LONG_DEFAULT_
     static _system      = __InputSystem();
     static _playerArray = __InputSystemPlayerArray();
     
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     with(_playerArray[_playerIndex].__verbStateArray[_verbIndex])
     {
         return (__held && ((_system.__frame - __pressFrame) >= _duration));

--- a/scripts/InputLongPressed/InputLongPressed.gml
+++ b/scripts/InputLongPressed/InputLongPressed.gml
@@ -12,6 +12,8 @@ function InputLongPressed(_verbIndex, _playerIndex = 0, _duration = INPUT_LONG_D
     static _system      = __InputSystem();
     static _playerArray = __InputSystemPlayerArray();
     
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     with(_playerArray[_playerIndex].__verbStateArray[_verbIndex])
     {
         return (__held && ((_system.__frame - __pressFrame) == _duration));

--- a/scripts/InputLongReleased/InputLongReleased.gml
+++ b/scripts/InputLongReleased/InputLongReleased.gml
@@ -12,6 +12,8 @@ function InputLongReleased(_verbIndex, _playerIndex = 0, _duration = INPUT_LONG_
     static _system      = __InputSystem();
     static _playerArray = __InputSystemPlayerArray();
     
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     with(_playerArray[_playerIndex].__verbStateArray[_verbIndex])
     {
         return (__prevHeld && (not __held) && ((_system.__frame - __pressFrame) >= _duration));

--- a/scripts/InputMostRecent/InputMostRecent.gml
+++ b/scripts/InputMostRecent/InputMostRecent.gml
@@ -14,6 +14,8 @@ function InputMostRecent(_verbIndexArray = -1, _playerIndex = 0)
     static _playerArray       = __InputSystemPlayerArray();
     static _verbDefIndexArray = _system.__verbDefIndexArray;
     
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     //Convert `-1` to the array of all verb definitions
     if (is_numeric(_verbIndexArray) && (_verbIndexArray == -1))
     {

--- a/scripts/InputMotionCalibrate/InputMotionCalibrate.gml
+++ b/scripts/InputMotionCalibrate/InputMotionCalibrate.gml
@@ -6,6 +6,8 @@ function InputMotionCalibrate(_playerIndex = 0)
 {
     static _deviceMap = __InputMotionSystem().__deviceMap;
     
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     var _deviceStruct = _deviceMap[? InputPlayerGetDevice(_playerIndex)];
     if (_deviceStruct == undefined) return;
     

--- a/scripts/InputMotionGet/InputMotionGet.gml
+++ b/scripts/InputMotionGet/InputMotionGet.gml
@@ -18,5 +18,7 @@
 
 function InputMotionGet(_playerIndex = 0)
 {
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
      return InputMotionGetDirect(InputPlayerGetDevice(_playerIndex));
 }

--- a/scripts/InputMotionIsCalibrated/InputMotionIsCalibrated.gml
+++ b/scripts/InputMotionIsCalibrated/InputMotionIsCalibrated.gml
@@ -6,6 +6,8 @@ function InputMotionIsCalibrated(_playerIndex = 0)
 {
     static _deviceMap = __InputMotionSystem().__deviceMap;
     
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     var _deviceStruct = _deviceMap[? InputPlayerGetDevice(_playerIndex)];
     if (_deviceStruct == undefined) return;
     

--- a/scripts/InputMotionSupported/InputMotionSupported.gml
+++ b/scripts/InputMotionSupported/InputMotionSupported.gml
@@ -4,5 +4,7 @@
 
 function InputMotionSupported(_playerIndex = 0)
 {
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
      return (InputMotionGetDirect(InputPlayerGetDevice(_playerIndex)) != undefined);
 }

--- a/scripts/InputOpposing/InputOpposing.gml
+++ b/scripts/InputOpposing/InputOpposing.gml
@@ -13,6 +13,8 @@ function InputOpposing(_verbNeg, _verbPos, _playerIndex = 0, _mostRecent = INPUT
 {
     static _playerArray = __InputSystemPlayerArray();
     
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     var _heldNeg = InputCheck(_verbNeg, _playerIndex);
     var _heldPos = InputCheck(_verbPos, _playerIndex);
     

--- a/scripts/InputOpposingPressed/InputOpposingPressed.gml
+++ b/scripts/InputOpposingPressed/InputOpposingPressed.gml
@@ -12,6 +12,8 @@
 
 function InputOpposingPressed(_verbNeg, _verbPos, _playerIndex = 0, _mostRecent = INPUT_OPPOSING_DEFAULT_MOST_RECENT)
 {
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     var _pressedNeg = InputPressed(_verbNeg, _playerIndex);
     var _pressedPos = InputPressed(_verbPos, _playerIndex);
 

--- a/scripts/InputOpposingRepeat/InputOpposingRepeat.gml
+++ b/scripts/InputOpposingRepeat/InputOpposingRepeat.gml
@@ -13,6 +13,8 @@
 
 function InputOpposingRepeat(_verbNeg, _verbPos, _playerIndex = 0, _delay = INPUT_REPEAT_DEFAULT_DELAY, _predelay = INPUT_REPEAT_DEFAULT_PREDELAY)
 {
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     if (InputCheck(_verbNeg, _playerIndex))
     {
         if (InputCheck(_verbPos, _playerIndex)) return 0;

--- a/scripts/InputPlayerGetBlocked/InputPlayerGetBlocked.gml
+++ b/scripts/InputPlayerGetBlocked/InputPlayerGetBlocked.gml
@@ -7,5 +7,8 @@
 function InputPlayerGetBlocked(_playerIndex = 0)
 {
     static _playerArray = __InputSystemPlayerArray();
+    
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     return _playerArray[_playerIndex].__blocked;
 }

--- a/scripts/InputPlayerGetDevice/InputPlayerGetDevice.gml
+++ b/scripts/InputPlayerGetDevice/InputPlayerGetDevice.gml
@@ -12,5 +12,8 @@
 function InputPlayerGetDevice(_playerIndex = 0)
 {
     static _playerArray = __InputSystemPlayerArray();
+    
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     return _playerArray[_playerIndex].__device;
 }

--- a/scripts/InputPlayerGetGamepadType/InputPlayerGetGamepadType.gml
+++ b/scripts/InputPlayerGetGamepadType/InputPlayerGetGamepadType.gml
@@ -16,5 +16,7 @@
 
 function InputPlayerGetGamepadType(_playerIndex = 0)
 {
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     return InputDeviceGetGamepadType(InputPlayerGetDevice(_playerIndex));
 }

--- a/scripts/InputPlayerGetGhost/InputPlayerGetGhost.gml
+++ b/scripts/InputPlayerGetGhost/InputPlayerGetGhost.gml
@@ -7,5 +7,8 @@
 function InputPlayerGetGhost(_playerIndex = 0)
 {
     static _playerArray = __InputSystemPlayerArray();
+    
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     return _playerArray[_playerIndex].__ghost;
 }

--- a/scripts/InputPlayerGetInactive/InputPlayerGetInactive.gml
+++ b/scripts/InputPlayerGetInactive/InputPlayerGetInactive.gml
@@ -9,5 +9,8 @@
 function InputPlayerGetInactive(_duration = 500, _playerIndex = 0)
 {
     static _playerArray = __InputSystemPlayerArray();
+    
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     return (current_time - _playerArray[_playerIndex].__lastInputTime > _duration);
 }

--- a/scripts/InputPlayerGetLastConnectedGamepadType/InputPlayerGetLastConnectedGamepadType.gml
+++ b/scripts/InputPlayerGetLastConnectedGamepadType/InputPlayerGetLastConnectedGamepadType.gml
@@ -18,5 +18,8 @@
 function InputPlayerGetLastConnectedGamepadType(_playerIndex = 0)
 {
     static _playerArray = __InputSystemPlayerArray();
+    
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     return _playerArray[_playerIndex].__lastConnectedGamepadType;
 }

--- a/scripts/InputPlayerGetMaxThreshold/InputPlayerGetMaxThreshold.gml
+++ b/scripts/InputPlayerGetMaxThreshold/InputPlayerGetMaxThreshold.gml
@@ -6,5 +6,8 @@
 function InputPlayerGetMaxThreshold(_thresholdType, _playerIndex = 0)
 {
     static _playerArray = __InputSystemPlayerArray();
+    
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     return _playerArray[_playerIndex].__thresholdMaxArray[_thresholdType];
 }

--- a/scripts/InputPlayerGetMetadata/InputPlayerGetMetadata.gml
+++ b/scripts/InputPlayerGetMetadata/InputPlayerGetMetadata.gml
@@ -10,6 +10,9 @@
 function InputPlayerGetMetadata(_playerIndex = 0, _makeCopy = false)
 {
     static _playerArray = __InputSystemPlayerArray();
+    
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     var _data = _playerArray[_playerIndex].__metadata;
     return _makeCopy? variable_clone(_data) : _data;
 }

--- a/scripts/InputPlayerGetMinThreshold/InputPlayerGetMinThreshold.gml
+++ b/scripts/InputPlayerGetMinThreshold/InputPlayerGetMinThreshold.gml
@@ -6,5 +6,8 @@
 function InputPlayerGetMinThreshold(_thresholdType, _playerIndex = 0)
 {
     static _playerArray = __InputSystemPlayerArray();
+    
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     return _playerArray[_playerIndex].__thresholdMinArray[_thresholdType];
 }

--- a/scripts/InputPlayerHasDevice/InputPlayerHasDevice.gml
+++ b/scripts/InputPlayerHasDevice/InputPlayerHasDevice.gml
@@ -6,5 +6,7 @@
 
 function InputPlayerHasDevice(_playerIndex = 0)
 {
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     return (InputPlayerGetDevice(_playerIndex) != INPUT_NO_DEVICE);
 }

--- a/scripts/InputPlayerIsConnected/InputPlayerIsConnected.gml
+++ b/scripts/InputPlayerIsConnected/InputPlayerIsConnected.gml
@@ -9,6 +9,9 @@
 function InputPlayerIsConnected(_playerIndex = 0)
 {
     static _playerArray = __InputSystemPlayerArray();
+    
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     with(_playerArray[_playerIndex])
     {
         return ((__status == INPUT_PLAYER_STATUS.NEWLY_CONNECTED) || (__status == INPUT_PLAYER_STATUS.CONNECTED));

--- a/scripts/InputPlayerSetBlocked/InputPlayerSetBlocked.gml
+++ b/scripts/InputPlayerSetBlocked/InputPlayerSetBlocked.gml
@@ -11,5 +11,8 @@
 function InputPlayerSetBlocked(_state, _playerIndex = 0)
 {
     static _playerArray = __InputSystemPlayerArray();
+    
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     _playerArray[_playerIndex].__blocked = _state;
 }

--- a/scripts/InputPlayerSetDevice/InputPlayerSetDevice.gml
+++ b/scripts/InputPlayerSetDevice/InputPlayerSetDevice.gml
@@ -18,6 +18,8 @@ function InputPlayerSetDevice(_device, _playerIndex = 0)
 {
     static _playerArray = __InputSystemPlayerArray();
     
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     var _oldDevice = _playerArray[_playerIndex].__device;
     
     //Don't do any work if the device hasn't changed

--- a/scripts/InputPlayerSetGhost/InputPlayerSetGhost.gml
+++ b/scripts/InputPlayerSetGhost/InputPlayerSetGhost.gml
@@ -15,5 +15,7 @@ function InputPlayerSetGhost(_state, _playerIndex = 0)
 {
     static _playerArray = __InputSystemPlayerArray();
     
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     _playerArray[_playerIndex].__ghost = _state;
 }

--- a/scripts/InputPlayerSetMaxThreshold/InputPlayerSetMaxThreshold.gml
+++ b/scripts/InputPlayerSetMaxThreshold/InputPlayerSetMaxThreshold.gml
@@ -8,6 +8,8 @@ function InputPlayerSetMaxThreshold(_thresholdType, _value, _playerIndex = 0)
 {
     static _playerArray = __InputSystemPlayerArray();
     
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     with(_playerArray[_playerIndex])
     {
         if (_thresholdType == INPUT_THRESHOLD.BOTH)

--- a/scripts/InputPlayerSetMetadata/InputPlayerSetMetadata.gml
+++ b/scripts/InputPlayerSetMetadata/InputPlayerSetMetadata.gml
@@ -11,6 +11,9 @@
 function InputPlayerSetMetadata(_data, _playerIndex = 0, _makeCopy = false)
 {
     static _playerArray = __InputSystemPlayerArray();
+    
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     if (_makeCopy) _data = variable_clone(_data);
     _playerArray[_playerIndex].__metadata = _data;
 }

--- a/scripts/InputPlayerSetMinThreshold/InputPlayerSetMinThreshold.gml
+++ b/scripts/InputPlayerSetMinThreshold/InputPlayerSetMinThreshold.gml
@@ -8,6 +8,8 @@ function InputPlayerSetMinThreshold(_thresholdType, _value, _playerIndex = 0)
 {
     static _playerArray = __InputSystemPlayerArray();
     
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     with(_playerArray[_playerIndex])
     {
         if (_thresholdType == INPUT_THRESHOLD.BOTH)

--- a/scripts/InputPlayerUsingGamepad/InputPlayerUsingGamepad.gml
+++ b/scripts/InputPlayerUsingGamepad/InputPlayerUsingGamepad.gml
@@ -7,5 +7,8 @@
 function InputPlayerUsingGamepad(_playerIndex = 0)
 {
     static _playerArray = __InputSystemPlayerArray();
+    
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     return InputDeviceIsGamepad(_playerArray[_playerIndex].__device);
 }

--- a/scripts/InputPlayerUsingGeneric/InputPlayerUsingGeneric.gml
+++ b/scripts/InputPlayerUsingGeneric/InputPlayerUsingGeneric.gml
@@ -7,5 +7,8 @@
 function InputPlayerUsingGeneric(_playerIndex = 0)
 {
     static _playerArray = __InputSystemPlayerArray();
+    
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     return (_playerArray[_playerIndex].__device == INPUT_GENERIC_DEVICE);
 }

--- a/scripts/InputPlayerUsingKbm/InputPlayerUsingKbm.gml
+++ b/scripts/InputPlayerUsingKbm/InputPlayerUsingKbm.gml
@@ -7,5 +7,8 @@
 function InputPlayerUsingKbm(_playerIndex = 0)
 {
     static _playerArray = __InputSystemPlayerArray();
+    
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     return (_playerArray[_playerIndex].__device == INPUT_KBM);
 }

--- a/scripts/InputPlayerUsingTouch/InputPlayerUsingTouch.gml
+++ b/scripts/InputPlayerUsingTouch/InputPlayerUsingTouch.gml
@@ -7,5 +7,8 @@
 function InputPlayerUsingTouch(_playerIndex = 0)
 {
     static _playerArray = __InputSystemPlayerArray();
+    
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     return (_playerArray[_playerIndex].__device == INPUT_TOUCH);
 }

--- a/scripts/InputPlugInVerbSet/InputPlugInVerbSet.gml
+++ b/scripts/InputPlugInVerbSet/InputPlugInVerbSet.gml
@@ -12,6 +12,8 @@ function InputPlugInVerbSet(_verbIndex, _value, _rawValue = _value, _playerIndex
     static _system      = __InputSystem();
     static _playerArray = __InputSystemPlayerArray();
     
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     if (_system.__plugInCurrentCallback != INPUT_PLUG_IN_CALLBACK.UPDATE_PLAYER)
     {
         __InputError("Cannot call InputPlugInVerbSet() outside of a INPUT_PLUG_IN_CALLBACK.UPDATE_PLAYER callback");

--- a/scripts/InputPlugInVerbStateRead/InputPlugInVerbStateRead.gml
+++ b/scripts/InputPlugInVerbStateRead/InputPlugInVerbStateRead.gml
@@ -10,6 +10,8 @@ function InputPlugInVerbStateRead(_buffer, _playerIndex = 0)
     static _system = __InputSystem();
     static _playerArray = __InputSystemPlayerArray();
     
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     if (_system.__plugInCurrentCallback != INPUT_PLUG_IN_CALLBACK.UPDATE_PLAYER)
     {
         __InputError("Cannot call InputPlugInVerbStateRead() outside of a INPUT_PLUG_IN_CALLBACK.UPDATE_PLAYER callback");

--- a/scripts/InputPlugInVerbStateSet/InputPlugInVerbStateSet.gml
+++ b/scripts/InputPlugInVerbStateSet/InputPlugInVerbStateSet.gml
@@ -14,6 +14,8 @@ function InputPlugInVerbStateSet(_verbIndex, _prevHeld = undefined, _valueRaw = 
     static _system = __InputSystem();
     static _playerArray = __InputSystemPlayerArray();
     
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     if (_system.__plugInCurrentCallback != INPUT_PLUG_IN_CALLBACK.UPDATE_PLAYER)
     {
         __InputError("Cannot call InputPlugInVerbStateSet() outside of a INPUT_PLUG_IN_CALLBACK.UPDATE_PLAYER callback");

--- a/scripts/InputPressed/InputPressed.gml
+++ b/scripts/InputPressed/InputPressed.gml
@@ -8,6 +8,9 @@
 function InputPressed(_verb, _playerIndex = 0)
 {
     static _playerArray = __InputSystemPlayerArray();
+    
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     with(_playerArray[_playerIndex].__verbStateArray[_verb])
     {
         return ((not __prevHeld) && __held);

--- a/scripts/InputReleased/InputReleased.gml
+++ b/scripts/InputReleased/InputReleased.gml
@@ -8,6 +8,9 @@
 function InputReleased(_verb, _playerIndex = 0)
 {
     static _playerArray = __InputSystemPlayerArray();
+    
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     with(_playerArray[_playerIndex].__verbStateArray[_verb])
     {
         return (__prevHeld && (not __held));

--- a/scripts/InputRepeat/InputRepeat.gml
+++ b/scripts/InputRepeat/InputRepeat.gml
@@ -14,6 +14,8 @@ function InputRepeat(_verbIndex, _playerIndex = 0, _delay = INPUT_REPEAT_DEFAULT
     static _system      = __InputSystem();
     static _playerArray = __InputSystemPlayerArray();
     
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     with(_playerArray[_playerIndex].__verbStateArray[_verbIndex])
     {
         if (not __held) return false;

--- a/scripts/InputTriggerEffectFeedback/InputTriggerEffectFeedback.gml
+++ b/scripts/InputTriggerEffectFeedback/InputTriggerEffectFeedback.gml
@@ -16,5 +16,7 @@ function InputTriggerEffectFeedback(_trigger, _position, _strength, _playerIndex
 {
     static _playerArray = __InputTriggerEffectSystem().__playerArray;
     
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     _playerArray[_playerIndex].__SetTriggerEffect(_trigger, new __InputTrggerEffectClassFeedback(_position, _strength), true);
 }

--- a/scripts/InputTriggerEffectGetPause/InputTriggerEffectGetPause.gml
+++ b/scripts/InputTriggerEffectGetPause/InputTriggerEffectGetPause.gml
@@ -8,5 +8,7 @@ function InputTriggerEffectGetPause(_playerIndex = 0)
 {
     static _playerArray = __InputTriggerEffectSystem().__playerArray;
     
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     return _playerArray[_playerIndex].__paused;
 }

--- a/scripts/InputTriggerEffectGetState/InputTriggerEffectGetState.gml
+++ b/scripts/InputTriggerEffectGetState/InputTriggerEffectGetState.gml
@@ -9,6 +9,8 @@ function InputTriggerEffectGetState(_trigger, _playerIndex = 0)
 {
     static _playerArray = __InputTriggerEffectSystem().__playerArray;
     
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     if not ((_trigger == gp_shoulderlb) || (_trigger == gp_shoulderrb))
     {
         __InputError("Value ", _trigger ," not a gamepad trigger");

--- a/scripts/InputTriggerEffectGetStrength/InputTriggerEffectGetStrength.gml
+++ b/scripts/InputTriggerEffectGetStrength/InputTriggerEffectGetStrength.gml
@@ -8,5 +8,7 @@ function InputTriggerEffectGetStrength(_playerIndex = 0)
 {
     static _playerArray = __InputTriggerEffectSystem().__playerArray;
     
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     return _playerArray[_playerIndex].__strength;
 }

--- a/scripts/InputTriggerEffectOff/InputTriggerEffectOff.gml
+++ b/scripts/InputTriggerEffectOff/InputTriggerEffectOff.gml
@@ -11,5 +11,7 @@ function InputTriggerEffectOff(_trigger, _playerIndex = 0)
 {
     static _playerArray = __InputTriggerEffectSystem().__playerArray;
     
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     _playerArray[_playerIndex].__SetTriggerEffect(_trigger, new __InputTriggerEffectClassOff(), true);
 }

--- a/scripts/InputTriggerEffectSetPause/InputTriggerEffectSetPause.gml
+++ b/scripts/InputTriggerEffectSetPause/InputTriggerEffectSetPause.gml
@@ -9,6 +9,8 @@ function InputTriggerEffectSetPause(_state, _playerIndex = 0)
 {
     static _playerArray = __InputTriggerEffectSystem().__playerArray;
     
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     if (_playerIndex == INPUT_ALL_PLAYERS)
     {
         var _i = 0;

--- a/scripts/InputTriggerEffectSetStrength/InputTriggerEffectSetStrength.gml
+++ b/scripts/InputTriggerEffectSetStrength/InputTriggerEffectSetStrength.gml
@@ -9,6 +9,8 @@ function InputTriggerEffectSetStrength(_strength, _playerIndex = 0)
 {
     static _playerArray = __InputTriggerEffectSystem().__playerArray;
     
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     if (_playerIndex == INPUT_ALL_PLAYERS)
     {
         var _i = 0;

--- a/scripts/InputTriggerEffectWeapon/InputTriggerEffectWeapon.gml
+++ b/scripts/InputTriggerEffectWeapon/InputTriggerEffectWeapon.gml
@@ -18,5 +18,7 @@ function InputTriggerEffectWeapon(_trigger, _start, _end, _strength, _playerInde
 {
     static _playerArray = __InputTriggerEffectSystem().__playerArray;
     
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     _playerArray[_playerIndex].__SetTriggerEffect(_trigger, new __InputTriggerEffectClassWeapon(_trigger, _start, _end, _strength), true);
 }

--- a/scripts/InputValue/InputValue.gml
+++ b/scripts/InputValue/InputValue.gml
@@ -9,5 +9,8 @@
 function InputValue(_verb, _playerIndex = 0)
 {
     static _playerArray = __InputSystemPlayerArray();
+    
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     return _playerArray[_playerIndex].__verbStateArray[_verb].__valueClamp;
 }

--- a/scripts/InputVerbConsume/InputVerbConsume.gml
+++ b/scripts/InputVerbConsume/InputVerbConsume.gml
@@ -10,6 +10,9 @@
 function InputVerbConsume(_verbIndex, _playerIndex = 0)
 {
     static _playerArray = __InputSystemPlayerArray();
+    
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     with(_playerArray[_playerIndex])
     {
         if (array_get_index(__consumedArray, __verbStateArray[_verbIndex]) < 0)

--- a/scripts/InputVerbConsumeAll/InputVerbConsumeAll.gml
+++ b/scripts/InputVerbConsumeAll/InputVerbConsumeAll.gml
@@ -11,7 +11,7 @@ function InputVerbConsumeAll(_playerIndex = 0)
     static _playerArray = __InputSystemPlayerArray();
     static _verbCount   = __InputSystem().__verbCount;
     
-    if (_playerIndex == undefined) return;
+    __INPUT_VALIDATE_PLAYER_INDEX
     
     with(_playerArray[_playerIndex])
     {

--- a/scripts/InputVerbGetBindingName/InputVerbGetBindingName.gml
+++ b/scripts/InputVerbGetBindingName/InputVerbGetBindingName.gml
@@ -119,6 +119,8 @@
 
 function InputVerbGetBindingName(_verbIndex, _alternate = 0, _playerIndex = 0, _missingBindingName = "???")
 {
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     var _forGamepad = InputPlayerUsingGamepad(_playerIndex);
     return InputGetBindingName(InputBindingGet(_forGamepad, _verbIndex, _alternate, _playerIndex),
                                   _forGamepad,

--- a/scripts/InputVerbGetMetadata/InputVerbGetMetadata.gml
+++ b/scripts/InputVerbGetMetadata/InputVerbGetMetadata.gml
@@ -11,6 +11,9 @@
 function InputVerbGetMetadata(_verb, _playerIndex = 0, _makeCopy = false)
 {
     static _playerArray = __InputSystemPlayerArray();
+    
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     var _data = _playerArray[_playerIndex].__verbMetadataArray[_verb];
     return _makeCopy? variable_clone(_data) : _data;
 }

--- a/scripts/InputVerbResetMetadata/InputVerbResetMetadata.gml
+++ b/scripts/InputVerbResetMetadata/InputVerbResetMetadata.gml
@@ -10,6 +10,8 @@ function InputVerbResetMetadata(_verb, _playerIndex = 0)
     static _verbDefinitionArray = __InputSystem().__verbDefinitionArray;
     static _playerArray         = __InputSystemPlayerArray();
     
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     var _verbMetadataArray = _playerArray[_playerIndex].__verbMetadataArray
     _verbMetadataArray[@ _verb] = variable_clone(_verbDefinitionArray[_verb].__metadata);
 }

--- a/scripts/InputVerbSetMetadata/InputVerbSetMetadata.gml
+++ b/scripts/InputVerbSetMetadata/InputVerbSetMetadata.gml
@@ -14,6 +14,8 @@ function InputVerbSetMetadata(_verb, _data, _playerIndex = 0, _makeCopy = false)
 {
     static _playerArray = __InputSystemPlayerArray();
     
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     var _verbMetadataArray = _playerArray[_playerIndex].__verbMetadataArray
     _verbMetadataArray[@ _verb] = _makeCopy? variable_clone(_data) : _data;
 }

--- a/scripts/InputVerbStateArray/InputVerbStateArray.gml
+++ b/scripts/InputVerbStateArray/InputVerbStateArray.gml
@@ -30,6 +30,8 @@ function InputVerbStateArray(_newArray = true, _playerIndex = 0)
     
     static _staticArray = array_create_ext(InputVerbCount(), _funcGenerate);
     
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     if (_newArray)
     {
         var _targetArray = array_create_ext(InputVerbCount(), _funcGenerate);

--- a/scripts/InputVerbStateWrite/InputVerbStateWrite.gml
+++ b/scripts/InputVerbStateWrite/InputVerbStateWrite.gml
@@ -19,6 +19,8 @@ function InputVerbStateWrite(_buffer, _playerIndex = 0)
     static _system = __InputSystem();
     static _playerArray = __InputSystemPlayerArray();
     
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     var _frame = _system.__frame;
     var _verbCount = InputVerbCount();
     

--- a/scripts/InputVibrateADSR/InputVibrateADSR.gml
+++ b/scripts/InputVibrateADSR/InputVibrateADSR.gml
@@ -18,6 +18,8 @@ function InputVibrateADSR(_peakStrength, _sustainLevel, _pan, _attack, _decay, _
 {
     static _playerArray = __InputVibrateSystem().__playerArray;
     
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     _peakStrength = clamp(_peakStrength, 0, 1);
     _sustainLevel = clamp(_sustainLevel, 0, 1);
     _pan          = clamp(_pan, -1, 1);

--- a/scripts/InputVibrateConstant/InputVibrateConstant.gml
+++ b/scripts/InputVibrateConstant/InputVibrateConstant.gml
@@ -14,6 +14,8 @@ function InputVibrateConstant(_strength, _pan, _duration, _playerIndex = 0, _for
 {
     static _playerArray = __InputVibrateSystem().__playerArray;
     
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     _strength = clamp(_strength, 0, 1);
     _pan      = clamp(_pan, -1, 1);
     _duration = max(_duration, 0);

--- a/scripts/InputVibratePulse/InputVibratePulse.gml
+++ b/scripts/InputVibratePulse/InputVibratePulse.gml
@@ -15,6 +15,8 @@ function InputVibratePulse(_strength, _pan, _repeats, _duration, _playerIndex = 
 {
     static _playerArray = __InputVibrateSystem().__playerArray;
     
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     _strength = clamp(_strength, 0, 1);
     _pan      = clamp(_pan, -1, 1);
     _repeats  = max(_repeats, 0);

--- a/scripts/InputX/InputX.gml
+++ b/scripts/InputX/InputX.gml
@@ -8,5 +8,8 @@
 function InputX(_clusterIndex, _playerIndex = 0)
 {
     static _playerArray = __InputSystemPlayerArray();
+    
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     return _playerArray[_playerIndex].__clusterXArray[_clusterIndex];
 }

--- a/scripts/InputY/InputY.gml
+++ b/scripts/InputY/InputY.gml
@@ -2,11 +2,14 @@
 
 /// Returns the y-coordinate of the vector represented by the sum of the verb values.
 /// 
-/// @param  {Enum.INPUT_CLUSTER,Real} clusterIndex
-/// @param  {Real} [playerIndex=0]
+/// @param {Enum.INPUT_CLUSTER,Real} clusterIndex
+/// @param {Real} [playerIndex=0]
 
 function InputY(_clusterIndex, _playerIndex = 0)
 {
     static _playerArray = __InputSystemPlayerArray();
+    
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
     return _playerArray[_playerIndex].__clusterYArray[_clusterIndex];
 }

--- a/scripts/__InputConfig/__InputConfig.gml
+++ b/scripts/__InputConfig/__InputConfig.gml
@@ -4,6 +4,11 @@
 // incur a slight performance penalty.
 #macro INPUT_MAX_PLAYERS  1
 
+// Whether the library should perform extra checks to validate parameters for functions. This will
+// catch small mistakes but also incurs a performance penalty. If you want maximum speed from the
+// library, set this macro to `false`.
+#macro INPUT_SAFETY_CHECKS  true
+
 ////////////////
 //            //
 //  Checkers  //

--- a/scripts/__InputSystem/__InputSystem.gml
+++ b/scripts/__InputSystem/__InputSystem.gml
@@ -10,6 +10,20 @@
 // exclusive (come talk to us if you need to be able to swap at runtime).
 #macro __INPUT_SWITCH_JOYCON_HORIZONTAL_HOLDTYPE  true
 
+#macro __INPUT_VALIDATE_PLAYER_INDEX ;\
+                                     if (not is_numeric(_playerIndex))\
+                                     {\
+                                         __InputError($"Player index must be a number (typeof = \"{typeof(_playerIndex)}\")");\
+                                     }\
+                                     if (_playerIndex > INPUT_MAX_PLAYERS)\
+                                     {\
+                                         __InputError($"Player index {_playerIndex} too large. Must be less than config `INPUT_MAX_PLAYERS` ({INPUT_MAX_PLAYERS})");\
+                                     }\
+                                     if (_playerIndex < 0)\
+                                     {\
+                                         __InputError($"Player index {_playerIndex} less than zero");\
+                                     }
+
 __InputSystem();
 function __InputSystem()
 {

--- a/scripts/__InputSystem/__InputSystem.gml
+++ b/scripts/__InputSystem/__InputSystem.gml
@@ -10,18 +10,20 @@
 // exclusive (come talk to us if you need to be able to swap at runtime).
 #macro __INPUT_SWITCH_JOYCON_HORIZONTAL_HOLDTYPE  true
 
-#macro __INPUT_VALIDATE_PLAYER_INDEX ;\
-                                     if (not is_numeric(_playerIndex))\
+#macro __INPUT_VALIDATE_PLAYER_INDEX if (INPUT_SAFETY_CHECKS)\
                                      {\
-                                         __InputError($"Player index must be a number (typeof = \"{typeof(_playerIndex)}\")");\
-                                     }\
-                                     if (_playerIndex > INPUT_MAX_PLAYERS)\
-                                     {\
-                                         __InputError($"Player index {_playerIndex} too large. Must be less than config `INPUT_MAX_PLAYERS` ({INPUT_MAX_PLAYERS})");\
-                                     }\
-                                     if (_playerIndex < 0)\
-                                     {\
-                                         __InputError($"Player index {_playerIndex} less than zero");\
+                                         if (not is_numeric(_playerIndex))\
+                                         {\
+                                             __InputError($"Player index must be a number (typeof = \"{typeof(_playerIndex)}\")");\
+                                         }\
+                                         if (_playerIndex >= INPUT_MAX_PLAYERS)\
+                                         {\
+                                             __InputError($"Player index {_playerIndex} too large. Must be less than config `INPUT_MAX_PLAYERS` ({INPUT_MAX_PLAYERS})");\
+                                         }\
+                                         if (_playerIndex < 0)\
+                                         {\
+                                             __InputError($"Player index {_playerIndex} less than zero");\
+                                         }\
                                      }
 
 __InputSystem();


### PR DESCRIPTION
Addresses #930. Public config macro `INPUT_SAFETY_CHECKS` has been added to toggle the player index validation on and off, and this macro could be used for other validation features in the future.