### PR TITLE
Removes erroneous `gamepadType` argument from `InputGetBindingName()`

### DIFF
--- a/scripts/InputGetBindingName/InputGetBindingName.gml
+++ b/scripts/InputGetBindingName/InputGetBindingName.gml
@@ -9,7 +9,6 @@
 /// 
 /// @param {Any} binding
 /// @param {Boolean} forGamepad
-/// @param {Real} gamepadType
 /// @param {Real} [missingBindingName="???"]
 /// 
 /// If `forGamepad` is set to `true` then one of the following will be returned. This is an
@@ -122,14 +121,14 @@
 ///   - `"page down"`
 ///   - `"end"`
 
-function InputGetBindingName(_binding, _forGamepad, _gamepadType, _missingBindingName = "???")
+function InputGetBindingName(_binding, _forGamepad, _missingBindingName = "???")
 {
     static _gamepadButtonNameLookup = __InputSystem().__gamepadButtonNameLookup;
     static _kbmBindingNameMap       = __InputSystem().__kbmBindingNameMap;
     
     if (_forGamepad)
     {
-        return _gamepadButtonNameLookup[_gamepadType][? _binding] ?? _missingBindingName;
+        return _gamepadButtonNameLookup[? _binding] ?? _missingBindingName;
     }
     else
     {

--- a/scripts/InputVerbGetBindingName/InputVerbGetBindingName.gml
+++ b/scripts/InputVerbGetBindingName/InputVerbGetBindingName.gml
@@ -123,7 +123,6 @@ function InputVerbGetBindingName(_verbIndex, _alternate = 0, _playerIndex = 0, _
     
     var _forGamepad = InputPlayerUsingGamepad(_playerIndex);
     return InputGetBindingName(InputBindingGet(_forGamepad, _verbIndex, _alternate, _playerIndex),
-                                  _forGamepad,
-                                  InputPlayerGetLastConnectedGamepadType(_playerIndex),
-                                  _missingBindingName);
+                               _forGamepad,
+                               _missingBindingName);
 }


### PR DESCRIPTION
`InputGetBindingName()` currently requires a gamepad type. This is entirely unnecessary and indeed targeting gamepads with this function causes a crash.

This PR fixes the crash and also fixes `InputVerbGetBindingName()` crashing when the player is using a gamepad.

N.B. If accepted, docs will need to be updated to excise `gamepadType` from the function description.