### PR TITLE
Fix for InputDeviceStopAllRebinding

### DIFF
--- a/scripts/InputDeviceStopAllRebinding/InputDeviceStopAllRebinding.gml
+++ b/scripts/InputDeviceStopAllRebinding/InputDeviceStopAllRebinding.gml
@@ -8,7 +8,7 @@ function InputDeviceStopAllRebinding()
     var _i = 0;
     repeat(array_length(_array))
     {
-        InputDeviceSetRebinding(_i, false);
+        InputDeviceSetRebinding(_array[_i], false);
         ++_i;
     }
 }


### PR DESCRIPTION
InputDeviceStopAllRebinding didn't access the device array, which caused rebinding to not be stopped properly