### PR TITLE
Fixed X and Y comments in nintendo icon config

### DIFF
--- a/scripts/__InputIconConfigNintendo/__InputIconConfigNintendo.gml
+++ b/scripts/__InputIconConfigNintendo/__InputIconConfigNintendo.gml
@@ -8,8 +8,8 @@
 
 InputIconDefineGamepad(INPUT_GAMEPAD_TYPE_SWITCH, gp_face1, "B"); //B
 InputIconDefineGamepad(INPUT_GAMEPAD_TYPE_SWITCH, gp_face2, "A"); //A
-InputIconDefineGamepad(INPUT_GAMEPAD_TYPE_SWITCH, gp_face3, "Y"); //X
-InputIconDefineGamepad(INPUT_GAMEPAD_TYPE_SWITCH, gp_face4, "X"); //Y
+InputIconDefineGamepad(INPUT_GAMEPAD_TYPE_SWITCH, gp_face3, "Y"); //Y
+InputIconDefineGamepad(INPUT_GAMEPAD_TYPE_SWITCH, gp_face4, "X"); //X
 
 InputIconDefineGamepad(INPUT_GAMEPAD_TYPE_SWITCH, gp_shoulderl,  "L"); //L
 InputIconDefineGamepad(INPUT_GAMEPAD_TYPE_SWITCH, gp_shoulderr,  "R"); //R


### PR DESCRIPTION
X and Y comments were backwards in nintendo icon config