### PR TITLE
Verb definition flag (replacing callstack checks)

### DIFF
--- a/scripts/InputDefineCluster/InputDefineCluster.gml
+++ b/scripts/InputDefineCluster/InputDefineCluster.gml
@@ -28,11 +28,7 @@ function InputDefineCluster(_clusterIndex, _verbUp, _verbRight, _verbDown, _verb
     
     if (GM_build_type == "run")
     {
-        var _callstack = debug_get_callstack(2);
-        var _previous = _callstack[1];
-        _previous = string_copy(_previous, 1, string_length("gml_Script___InputConfigVerbs"))
-        
-        if (_previous != "gml_Script___InputConfigVerbs")
+        if not (_system.__verbDefineAllowed)
         {
             __InputError("InputDefineCluster() must only be called in __InputConfigVerbs()");
         }

--- a/scripts/InputDefineVerb/InputDefineVerb.gml
+++ b/scripts/InputDefineVerb/InputDefineVerb.gml
@@ -27,11 +27,7 @@ function InputDefineVerb(_verbIndex, _exportName, _kbmBinding, _gamepadBinding, 
     
     if (GM_build_type == "run")
     {
-        var _callstack = debug_get_callstack(2);
-        var _previous = _callstack[1];
-        _previous = string_copy(_previous, 1, string_length("gml_Script___InputConfigVerbs"))
-        
-        if (_previous != "gml_Script___InputConfigVerbs")
+        if not (_system.__verbDefineAllowed)
         {
             __InputError("InputDefineVerb() must only be called in __InputConfigVerbs()");
         }

--- a/scripts/__InputSystem/__InputSystem.gml
+++ b/scripts/__InputSystem/__InputSystem.gml
@@ -80,6 +80,9 @@ function __InputSystem()
         
         __androidEnumerationTime = -infinity;
         __restartTime            = -infinity;
+
+        //Flag for toggling InputDefineVerb() and InputDefineCluster() with __InputConfigVerbs()
+        __verbDefineAllowed = false;
         
         //Master definitions for verbs
         __verbDefinitionArray = []; //Contains structs for each verb definition
@@ -193,8 +196,9 @@ function __InputSystem()
         ];
         
         
-        
+        __verbDefineAllowed = true;
         __InputConfigVerbs();
+        __verbDefineAllowed = false;
         
         
         


### PR DESCRIPTION
HTML5 doesn't work at all when going off by `debug_get_callstack()` in situations where code is obfuscated.
This change remedies this by instead introducing a flag for toggling on/off within `__InputSystem()`, to allow `InputDefineVerb()` and `InputDefineCluster()` when only called within `__InputConfigVerbs()`.