### PR TITLE
Add Feather disable/annotations where missing

### DIFF
--- a/scripts/InputDefineVerb/InputDefineVerb.gml
+++ b/scripts/InputDefineVerb/InputDefineVerb.gml
@@ -1,4 +1,4 @@
-/// feather disable all
+// Feather disable all
 
 /// Defines a verb and its default bindings for keyboard+mouse and gamepad. The `exportName`
 /// parameters defines the name of the verb when exported with InputBindingsExport().

--- a/scripts/__InputBindingScan/__InputBindingScan.gml
+++ b/scripts/__InputBindingScan/__InputBindingScan.gml
@@ -1,3 +1,9 @@
+// Feather disable all
+
+/// @param device
+/// @param ignoreStruct
+/// @param allowStruct
+
 function __InputBindingScan(_device, _ignoreStruct, _allowStruct)
 {
     static _system = __InputSystem();

--- a/scripts/__InputConfigVerbs/__InputConfigVerbs.gml
+++ b/scripts/__InputConfigVerbs/__InputConfigVerbs.gml
@@ -1,5 +1,3 @@
-// Feather disable all
-
 function __InputConfigVerbs()
 {
     enum INPUT_VERB

--- a/scripts/__InputConfigVerbs/__InputConfigVerbs.gml
+++ b/scripts/__InputConfigVerbs/__InputConfigVerbs.gml
@@ -1,3 +1,5 @@
+// Feather disable all
+
 function __InputConfigVerbs()
 {
     enum INPUT_VERB

--- a/scripts/__InputGamepadIdentifyDescriptionType/__InputGamepadIdentifyDescriptionType.gml
+++ b/scripts/__InputGamepadIdentifyDescriptionType/__InputGamepadIdentifyDescriptionType.gml
@@ -1,3 +1,7 @@
+// Feather disable all
+
+/// @param description
+
 function __InputGamepadIdentifyDescriptionType(_description)
 {
     _description = string_lower(_description);

--- a/scripts/__InputGamepadIdentifySwitchType/__InputGamepadIdentifySwitchType.gml
+++ b/scripts/__InputGamepadIdentifySwitchType/__InputGamepadIdentifySwitchType.gml
@@ -1,3 +1,5 @@
+// Feather disable all
+
 /// @param gamepadIndex
 /// @param [description]
 

--- a/scripts/__InputSystemCallbackArray/__InputSystemCallbackArray.gml
+++ b/scripts/__InputSystemCallbackArray/__InputSystemCallbackArray.gml
@@ -1,3 +1,5 @@
+// Feather disable all
+
 // We store the callback array separately as the System initialization flow
 
 function __InputSystemCallbackArray()


### PR DESCRIPTION
Disables Feather in several files where it's missing for consistency. Also adds `@param` annotations in adjusted files where relevant.

The omission of disabling Feather in `__InputConfigVerbs` may be deliberate, as it's the most universally user-modified file. If so, I can revert that addition.
