### PR TITLE
Fixes console gamepad not being assigned to P1 on boot

### DIFF
--- a/scripts/__InputConstants/__InputConstants.gml
+++ b/scripts/__InputConstants/__InputConstants.gml
@@ -134,7 +134,7 @@ enum INPUT_PLUG_IN_CALLBACK
 
 //How many milliseconds to wait before scanning for connected gamepads
 //This works around Steam sometimes reporting confusing connection/disconnection events on boot
-#macro INPUT_GAMEPADS_COLLECT_PREDELAY  1000 //milliseconds
+#macro INPUT_GAMEPADS_COLLECT_PREDELAY  (INPUT_ON_CONSOLE? 0 : 1000) //milliseconds
 
 //How many milliseconds to wait before considering a gamepad disconnected
 //This works around momentary disconnections such as a jiggled cable or low battery level


### PR DESCRIPTION
Input, on all platforms, will try to assign a valid connected device to P1 (index=0) as soon as possible on boot. This is a developer-oriented UX affordance that gets Input running in a valid and usable state without extra work from the developer. On console, we scan through connected gamepads and assign the first connected gamepad to P1.

Unfortunately, we wait for 1000ms (as per `INPUT_GAMEPADS_COLLECT_PREDELAY`) before determining if a gamepad hardware is connected. This means Input is never aware of any connected gamepads when we try to assign a default device to P1.

This PR fixes the problem by forcing a gamepad presence update on console before scanning for connected devices. This PR also pushes `INPUT_GAMEPADS_COLLECT_PREDELAY` to 0ms on console platforms because keeping it at 1000ms feels superfluous when we're already updating one time on boot already.

This is a theory-crafted PR. I don't have console hardware set up at the moment to test properly and this PR may cause other issues. Forcing console mode on desktop doesn't show any obvious flaws, however, so I think it's safe?