### PR TITLE
Unsets rebinding state when assigning a device

### DIFF
--- a/scripts/InputDeviceSetRebinding/InputDeviceSetRebinding.gml
+++ b/scripts/InputDeviceSetRebinding/InputDeviceSetRebinding.gml
@@ -14,8 +14,9 @@
 /// @param {Bool} state
 /// @param {Array<Enum.INPUT_VERB,Real>} [ignoreArray]
 /// @param {Array<Enum.INPUT_VERB,Real>} [allowArray]
+/// @param {Bool} [consume=true]
 
-function InputDeviceSetRebinding(_device, _state, _ignoreArray = undefined, _allowArray = undefined)
+function InputDeviceSetRebinding(_device, _state, _ignoreArray = undefined, _allowArray = undefined, _consume = true)
 {
     static _rebindingMap   = __InputSystem().__rebindingMap;
     static _rebindingArray = __InputSystem().__rebindingArray;
@@ -33,7 +34,10 @@ function InputDeviceSetRebinding(_device, _state, _ignoreArray = undefined, _all
             _rebindingMap[? _device] = _handler;
             array_push(_rebindingArray, _handler);
             
-            InputVerbConsumeAll(InputDeviceGetPlayer(_device));
+            if (_consume)
+            {
+                InputVerbConsumeAll(InputDeviceGetPlayer(_device));
+            }
         }
     }
     else
@@ -55,7 +59,10 @@ function InputDeviceSetRebinding(_device, _state, _ignoreArray = undefined, _all
                 }
             }
             
-            InputVerbConsumeAll(InputDeviceGetPlayer(_device));
+            if (_consume)
+            {
+                InputVerbConsumeAll(InputDeviceGetPlayer(_device));
+            }
         }
     }
 }

--- a/scripts/__InputRegisterPlayerDeviceChanged/__InputRegisterPlayerDeviceChanged.gml
+++ b/scripts/__InputRegisterPlayerDeviceChanged/__InputRegisterPlayerDeviceChanged.gml
@@ -53,6 +53,9 @@ function __InputRegisterPlayerDeviceChanged()
             //Immediately update status
             __UpdateStatus();
             
+            //Make sure this device isn't rebinding
+            InputDeviceSetRebinding(__device, false);
+            
             //Block other players from using this device
             if ((_device != INPUT_NO_DEVICE) && (_device != INPUT_GENERIC_DEVICE))
             {


### PR DESCRIPTION
[As noticed on Discord](https://discord.com/channels/724320164371497020/1366084579219214365/1411128930815184936), setting a player's device does not clear the rebinding state for the outgoing device. This is confusing and could potentially cause weird problems in multiplayer titles specifically.