### PR TITLE
Removed duplicate PlugInError entries

### DIFF
--- a/docs/10.1/Functions-(Plug-ins).md
+++ b/docs/10.1/Functions-(Plug-ins).md
@@ -590,30 +590,6 @@ A list of valid gamepad types can be found [here](Functions-(Player)?id=getgamep
 
 &nbsp;
 
-## …PlugInError
-
-`InputPlugInError(value1, [value2], [...])`
-
-<!-- tabs:start -->
-
-#### **Description**
-
-**Returns:** N/A (`undefined`)
-
-|Name        |Datatype       |Purpose                                |
-|------------|---------------|---------------------------------------|
-|`value[1-n]`|any            |Value to stringify                     |
-
-#### **Example**
-
-```gml
-{
-    
-}
-```
-<!-- tabs:end -->
-&nbsp;
-
 ## …PlugInWarning
 
 `InputPlugInWarning(value1, [value2], [...])`

--- a/docs/10.2/Functions-(Plug-ins).md
+++ b/docs/10.2/Functions-(Plug-ins).md
@@ -590,30 +590,6 @@ A list of valid gamepad types can be found [here](Functions-(Player)?id=getgamep
 
 &nbsp;
 
-## …PlugInError
-
-`InputPlugInError(value1, [value2], [...])`
-
-<!-- tabs:start -->
-
-#### **Description**
-
-**Returns:** N/A (`undefined`)
-
-|Name        |Datatype       |Purpose                                |
-|------------|---------------|---------------------------------------|
-|`value[1-n]`|any            |Value to stringify                     |
-
-#### **Example**
-
-```gml
-{
-    
-}
-```
-<!-- tabs:end -->
-&nbsp;
-
 ## …PlugInWarning
 
 `InputPlugInWarning(value1, [value2], [...])`


### PR DESCRIPTION
Noticed this just now while I was browsing the documentation. This seems to be a copy error from when introducing InputPlugInWarning. Appears in two versions.

<img width="257" height="744" alt="image" src="https://github.com/user-attachments/assets/a81aef9a-05f9-4761-bb8d-69ab59dbbc66" />
