### PR TITLE
fix: incorrect inverse rotation mixing sin/cos

### DIFF
--- a/scripts/__InputCursorClassPlayer/__InputCursorClassPlayer.gml
+++ b/scripts/__InputCursorClassPlayer/__InputCursorClassPlayer.gml
@@ -142,7 +142,7 @@ function __InputCursorClassPlayer(_playerIndex) constructor
                         _rotatedY = clamp(_rotatedY, _t + __limitMargin - _pivotY, _b - __limitMargin - _pivotY);
                         
                         __x =  _rotatedX*_cos + _rotatedY*_sin + _pivotX;
-   						__y = -_rotatedX*_sin + _rotatedY*_cos + _pivotY;
+                        __y = -_rotatedX*_sin + _rotatedY*_cos + _pivotY;
                         
                         //No need to apply the rest of the logic
                         return;

--- a/scripts/__InputCursorClassPlayer/__InputCursorClassPlayer.gml
+++ b/scripts/__InputCursorClassPlayer/__InputCursorClassPlayer.gml
@@ -141,8 +141,8 @@ function __InputCursorClassPlayer(_playerIndex) constructor
                         _rotatedX = clamp(_rotatedX, _l + __limitMargin - _pivotX, _r - __limitMargin - _pivotX);
                         _rotatedY = clamp(_rotatedY, _t + __limitMargin - _pivotY, _b - __limitMargin - _pivotY);
                         
-                        __x =  _rotatedX*_sin + _rotatedY*_cos + _pivotX;
-                        __y = -_rotatedX*_sin + _rotatedY*_cos + _pivotY;
+                        __x =  _rotatedX*_cos + _rotatedY*_sin + _pivotX;
+   						__y = -_rotatedX*_sin + _rotatedY*_cos + _pivotY;
                         
                         //No need to apply the rest of the logic
                         return;


### PR DESCRIPTION
This PR fixes a bug in the camera rotation handling code where __x and __y could end up with the same value when the camera was rotated by 180 degrees (and potentially other angles).

When the view angle (_viewA) was non-zero, the inverse rotation formula mistakenly used sin instead of cos when transforming back from rotated coordinates. 
As a result, the X and Y coordinates became identical, particularly visible when _viewA = 180.

The final inverse rotation step was implemented as:
```gml
__x =  _rotatedX * _sin + _rotatedY * _cos + _pivotX;
__y = -_rotatedX * _sin + _rotatedY * _cos + _pivotY;
```
The corrected formula properly applies the cosine to the X axis:
```gml
__x =  _rotatedX * _cos + _rotatedY * _sin + _pivotX;
__y = -_rotatedX * _sin + _rotatedY * _cos + _pivotY;
```
