### PR TITLE
Removes debug spam on Switch

### DIFF
--- a/scripts/__InputGamepadDiscover/__InputGamepadDiscover.gml
+++ b/scripts/__InputGamepadDiscover/__InputGamepadDiscover.gml
@@ -19,7 +19,7 @@ function __InputGamepadDiscover(_gamepadStruct)
         
         if (INPUT_ON_SWITCH)
         {
-            __type = __InputGamepadIdentifySwitchType(_device, __description);
+            __type = __InputGamepadIdentifySwitchType(_device, __description, true);
             
             //Going full custom
             InputPlugInGamepadNullifyAllMappings(_device);

--- a/scripts/__InputGamepadIdentifySwitchType/__InputGamepadIdentifySwitchType.gml
+++ b/scripts/__InputGamepadIdentifySwitchType/__InputGamepadIdentifySwitchType.gml
@@ -2,8 +2,9 @@
 
 /// @param gamepadIndex
 /// @param [description]
+/// @param [logWarnings=true]
 
-function __InputGamepadIdentifySwitchType(_gamepadIndex, _description = gamepad_get_description(_gamepadIndex))
+function __InputGamepadIdentifySwitchType(_gamepadIndex, _description = gamepad_get_description(_gamepadIndex), _logWarnings = true)
 {
     if (_description == "Joy-Con")
     {
@@ -14,7 +15,10 @@ function __InputGamepadIdentifySwitchType(_gamepadIndex, _description = gamepad_
         //       It also probably affects runtime:
         //       - v2024.1100.0.658
         
-        __InputTrace("Warning! Using stop-gap identification for bad description \"Joy-Con\"");
+        if (_logWarnings)
+        {
+            __InputTrace("Warning! Using stop-gap identification for bad description \"Joy-Con\"");
+        }
         
         var _left  = switch_controller_joycon_left_connected( _gamepadIndex);
         var _right = switch_controller_joycon_right_connected(_gamepadIndex);
@@ -39,7 +43,11 @@ function __InputGamepadIdentifySwitchType(_gamepadIndex, _description = gamepad_
             }
             else
             {
-                __InputTrace("Warning! Invalid left/right Joy-Con state, falling back on handheld");
+                if (_logWarnings)
+                {
+                    __InputTrace("Warning! Invalid left/right Joy-Con state, falling back on handheld");
+                }
+                
                 return INPUT_GAMEPAD_TYPE_SWITCH;
             }
         }

--- a/scripts/__InputRegisterCollect/__InputRegisterCollect.gml
+++ b/scripts/__InputRegisterCollect/__InputRegisterCollect.gml
@@ -239,7 +239,7 @@ function __InputUpdateGamepadPresence()
         {
             if (_connected)
             {
-                if (INPUT_ON_SWITCH && (_gamepad.__type != __InputGamepadIdentifySwitchType(_device)))
+                if (INPUT_ON_SWITCH && (_gamepad.__type != __InputGamepadIdentifySwitchType(_device, false)))
                 {
                     //When Switch L+R assignment is used to pair two gamepads we won't see a normal disconnection/reconnection
                     //Instead we have to check for changes via the gamepad description or Joy-Con left/right connected state


### PR DESCRIPTION
When running on Switch hardware, `__InputGamepadIdentifySwitchType()` spits out a stream of warning messages due to its use in the Step event via `__InputRegisterCollect()`.

This PR adds an optional argument to `__InputGamepadIdentifySwitchType()` to control whether warning messages should be outputted. This is then used when initially discovering a gamepad but not used in the Step event.