### PR TITLE
Adds gamepad input type awareness when planning hotswapping

### DIFF
--- a/scripts/__InputClassPlayer/__InputClassPlayer.gml
+++ b/scripts/__InputClassPlayer/__InputClassPlayer.gml
@@ -19,6 +19,11 @@ function __InputClassPlayer(_playerIndex) constructor
     __anyInput       = false;
     __lastInputTime  = -infinity;
     
+    //Most devices will block hotswap with any input. However, gamepads will not block hotswap for
+    //analogue (axis) input owing to the potential for false positives.
+    __hotswapBlocked = false;
+    __lastHotswapBlockedTime = -infinity;
+    
     //Set the last connected gamepad speculatively based on the platform / gamepad ban setting
     if (INPUT_BAN_GAMEPADS)
     {
@@ -313,6 +318,16 @@ function __InputClassPlayer(_playerIndex) constructor
             ++_i;
         }
         
-        if (__anyInput) __lastInputTime = current_time;
+        if (__anyInput)
+        {
+            __lastInputTime = current_time;
+            
+            //If we're not using a gampead, block hotswap for any verb input. However, if we're using a gamepad
+            //then only allow hotswap if no digital (button) input is detected.
+            if ((__device < 0) || (__INPUT_GAMEPAD_AXIS_BLOCKS_HOTSWAP || __hotswapBlocked))
+            {
+                __lastHotswapBlockedTime = current_time;
+            }
+        }
     }
 }

--- a/scripts/__InputRegisterCollect/__InputRegisterCollect.gml
+++ b/scripts/__InputRegisterCollect/__InputRegisterCollect.gml
@@ -186,8 +186,9 @@ function __InputRegisterCollect()
         {
             if (__hotswap)
             {
-                //No active verb
-                if (InputPlayerGetInactive())
+                //No active verb within the last 0.5 seconds. If we're using a gamepad then this timer is only reset
+                //if a digital button is pressed.
+                if (current_time - _playerArray[0].__lastHotswapBlockedTime > 500)
                 {
                     //No active device input
                     if (not InputDeviceIsActive(InputPlayerGetDevice()))

--- a/scripts/__InputRegisterCollectPlayer/__InputRegisterCollectPlayer.gml
+++ b/scripts/__InputRegisterCollectPlayer/__InputRegisterCollectPlayer.gml
@@ -59,6 +59,7 @@ function __InputRegisterCollectPlayer()
                     var _maxRight = __thresholdMaxArray[INPUT_THRESHOLD.RIGHT];
                     
                     __lastConnectedGamepadType = InputDeviceGetGamepadType(_device);
+                    var _hotswapBlocked = false;
                     
                     var _readArray = __InputGamepadGetReadArray(_device);
                     
@@ -86,6 +87,8 @@ function __InputRegisterCollectPlayer()
                                     if ((_absBinding == gp_shoulderlb) || (_absBinding == gp_shoulderrb))
                                     {
                                         _valueClamp = clamp((_raw - INPUT_GAMEPAD_TRIGGER_MIN_THRESHOLD) / (INPUT_GAMEPAD_TRIGGER_MAX_THRESHOLD - INPUT_GAMEPAD_TRIGGER_MIN_THRESHOLD), 0, 1);
+                                        //Technically we should detect if the trigger input is a button or not. However, this information is hard
+                                        //to obtain and it's probably fine if triggers don't block hotswap.
                                     }
                                     else if ((_absBinding == gp_axislh) || (_absBinding == gp_axislv))
                                     {
@@ -98,6 +101,7 @@ function __InputRegisterCollectPlayer()
                                     else
                                     {
                                         _valueClamp = (_raw > 0);
+                                        _hotswapBlocked = true; //Block hotswap on a button
                                     }
                                 }
                             }
@@ -110,6 +114,8 @@ function __InputRegisterCollectPlayer()
                         
                         ++_i;
                     }
+                    
+                    __hotswapBlocked = _hotswapBlocked;
                 }
                 else if (_device == INPUT_KBM)
                 {

--- a/scripts/__InputSystem/__InputSystem.gml
+++ b/scripts/__InputSystem/__InputSystem.gml
@@ -1,5 +1,7 @@
 // Feather disable all
 
+#macro __INPUT_GAMEPAD_AXIS_BLOCKS_HOTSWAP  false
+
 #macro __INPUT_VERB_STATE_HEADER  "<PWP"
 #macro __INPUT_VERB_STATE_FOOTER  ">"
 


### PR DESCRIPTION
As per discussions on Discord, this PR will prevent gamepad axes and triggers from blocking a hotswap. This will allow players to hotswap away from faulty gamepads/bluetooth connections where a gamepad axis is stuck at a particular value.

However, this method has shortcomings. Firstly, triggers are presumed to be analogue. This means trigger input will not block hotswap regardless of whether the input is analogue or not. Secondly, this method isn't aware of the gamepad mapping itself. Input type detection is based on a normative gamepad where thumbstick axis is always analogue. This isn't necessarily the case for all gamepads.