### PR TITLE
Adds more time-aware verb getter functions

### DIFF
--- a/input.yyp
+++ b/input.yyp
@@ -386,6 +386,7 @@
     {"id":{"name":"InputVirtualDebugDraw","path":"scripts/InputVirtualDebugDraw/InputVirtualDebugDraw.yy",},},
     {"id":{"name":"InputVirtualDestroyAll","path":"scripts/InputVirtualDestroyAll/InputVirtualDestroyAll.yy",},},
     {"id":{"name":"InputX","path":"scripts/InputX/InputX.yy",},},
+    {"id":{"name":"InputXYNewest","path":"scripts/InputXYNewest/InputXYNewest.yy",},},
     {"id":{"name":"InputXYOldest","path":"scripts/InputXYOldest/InputXYOldest.yy",},},
     {"id":{"name":"InputY","path":"scripts/InputY/InputY.yy",},},
   ],

--- a/input.yyp
+++ b/input.yyp
@@ -280,6 +280,7 @@
     {"id":{"name":"InputMouseRoomX","path":"scripts/InputMouseRoomX/InputMouseRoomX.yy",},},
     {"id":{"name":"InputMouseRoomY","path":"scripts/InputMouseRoomY/InputMouseRoomY.yy",},},
     {"id":{"name":"InputMouseSetBlocked","path":"scripts/InputMouseSetBlocked/InputMouseSetBlocked.yy",},},
+    {"id":{"name":"InputOldest","path":"scripts/InputOldest/InputOldest.yy",},},
     {"id":{"name":"InputOpposing","path":"scripts/InputOpposing/InputOpposing.yy",},},
     {"id":{"name":"InputOpposingPressed","path":"scripts/InputOpposingPressed/InputOpposingPressed.yy",},},
     {"id":{"name":"InputOpposingRepeat","path":"scripts/InputOpposingRepeat/InputOpposingRepeat.yy",},},

--- a/input.yyp
+++ b/input.yyp
@@ -386,6 +386,7 @@
     {"id":{"name":"InputVirtualDebugDraw","path":"scripts/InputVirtualDebugDraw/InputVirtualDebugDraw.yy",},},
     {"id":{"name":"InputVirtualDestroyAll","path":"scripts/InputVirtualDestroyAll/InputVirtualDestroyAll.yy",},},
     {"id":{"name":"InputX","path":"scripts/InputX/InputX.yy",},},
+    {"id":{"name":"InputXYOldest","path":"scripts/InputXYOldest/InputXYOldest.yy",},},
     {"id":{"name":"InputY","path":"scripts/InputY/InputY.yy",},},
   ],
   "resourceType":"GMProject",

--- a/objects/objTest002_Clusters/Draw_0.gml
+++ b/objects/objTest002_Clusters/Draw_0.gml
@@ -3,6 +3,8 @@ var _string = string_join("\n",
     string_concat("y = ", InputY(INPUT_CLUSTER.NAVIGATION)),
     string_concat("distance = ", InputDistance(INPUT_CLUSTER.NAVIGATION)),
     string_concat("direction = ", InputDirection(inputDirection, INPUT_CLUSTER.NAVIGATION)),
+    string_concat("xy oldest (prefer x) = ", InputXYOldest(INPUT_CLUSTER.NAVIGATION, true)),
+    string_concat("xy oldest (prefer y) = ", InputXYOldest(INPUT_CLUSTER.NAVIGATION, false)),
 );
 
 draw_text(10, 10, _string);

--- a/objects/objTest002_Clusters/Draw_0.gml
+++ b/objects/objTest002_Clusters/Draw_0.gml
@@ -3,8 +3,10 @@ var _string = string_join("\n",
     string_concat("y = ", InputY(INPUT_CLUSTER.NAVIGATION)),
     string_concat("distance = ", InputDistance(INPUT_CLUSTER.NAVIGATION)),
     string_concat("direction = ", InputDirection(inputDirection, INPUT_CLUSTER.NAVIGATION)),
-    string_concat("xy oldest (prefer x) = ", InputXYOldest(INPUT_CLUSTER.NAVIGATION, true)),
-    string_concat("xy oldest (prefer y) = ", InputXYOldest(INPUT_CLUSTER.NAVIGATION, false)),
+    string_concat("oldest (prefer x) = ", InputXYOldest(INPUT_CLUSTER.NAVIGATION, true)),
+    string_concat("oldest (prefer y) = ", InputXYOldest(INPUT_CLUSTER.NAVIGATION, false)),
+    string_concat("newest (prefer x) = ", InputXYNewest(INPUT_CLUSTER.NAVIGATION, true)),
+    string_concat("newest (prefer y) = ", InputXYNewest(INPUT_CLUSTER.NAVIGATION, false)),
 );
 
 draw_text(10, 10, _string);

--- a/scripts/InputOldest/InputOldest.gml
+++ b/scripts/InputOldest/InputOldest.gml
@@ -1,0 +1,47 @@
+// Feather disable all
+
+/// Returns the verb that has been pressed for the longest time that is still active from among the
+/// array of verbs provided. If no verb array is provided (or the value `-1` is used in place of an
+/// array), all defined verbs will be checked instead. If no verb in the array is active, this
+/// function returns `undefined`.
+/// 
+/// @param {Enum.INPUT_VERB,Real,Array} [verbIndexArray=all]
+/// @param {Real} [playerIndex=0]
+
+function InputOldest(_verbIndexArray = -1, _playerIndex = 0)
+{
+    static _system            = __InputSystem();
+    static _playerArray       = __InputSystemPlayerArray();
+    static _verbDefIndexArray = _system.__verbDefIndexArray;
+    
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
+    //Convert `-1` to the array of all verb definitions
+    if (is_numeric(_verbIndexArray) && (_verbIndexArray == -1))
+    {
+        _verbIndexArray = _verbDefIndexArray;
+    }
+    
+    with(_playerArray[_playerIndex])
+    {
+        var _minTime = -1;
+        var _minVerb = undefined;
+        
+        var _i = 0;
+        repeat(array_length(_verbIndexArray))
+        {
+            var _verbIndex = _verbIndexArray[_i];
+            
+            var _verbState = __verbStateArray[_verbIndex];
+            if (_verbState.__held && (_verbState.__pressFrame < _minTime))
+            {
+                _minTime = _verbState.__pressFrame;
+                _minVerb = _verbIndex;
+            }
+            
+            ++_i;
+        }
+        
+        return _minVerb;
+    }
+}

--- a/scripts/InputOldest/InputOldest.yy
+++ b/scripts/InputOldest/InputOldest.yy
@@ -1,0 +1,13 @@
+{
+  "$GMScript":"v1",
+  "%Name":"InputOldest",
+  "isCompatibility":false,
+  "isDnD":false,
+  "name":"InputOldest",
+  "parent":{
+    "name":"Many",
+    "path":"folders/Input/Checkers/Many.yy",
+  },
+  "resourceType":"GMScript",
+  "resourceVersion":"2.0",
+}

--- a/scripts/InputXYNewest/InputXYNewest.gml
+++ b/scripts/InputXYNewest/InputXYNewest.gml
@@ -1,13 +1,13 @@
 // Feather disable all
 
-/// Returns along which axis, and what direction on that axis, the oldest held direction is
-/// pointing in. This is helpful for games where the player will typically instead to move along
-/// grid lines and off-axis movement is erroneous.
+/// Returns along which axis, and what direction on that axis, the newest held direction is
+/// pointing in. This is helpful for games where the player is only permitted to move in cardinal
+/// directions and want to respect the most recent input for tighter-feeling controls.
 /// 
-/// For example, if the player holds `left` and then subsequently presses and holds `up` then this
-/// function will return `{ x: -1, y: 0}`. If the player releases `left` and keeps `up` held then
-/// this function will return `{ x: 0, y: -1 }`. If the player relases `up` (so no verbs are held
-/// then the function will return `{ x: 0, y: 0 }`.
+/// For example, if the player holds `right` and then subsequently presses and holds `down` then
+/// this function will return `{ x: 0, y: 1}`. If the player releases `down` and keeps `right` held
+/// then this function will return `{ x: 1, y: 0 }`. If the player relases `right` (so no verbs are
+/// held then the function will return `{ x: 0, y: 0 }`.
 /// 
 /// This function returns a struct that contains two member variables `x` and `y`. These values
 /// will always be either `0` `+1` or `-1` and only one axis cam be non-zero. This means this

--- a/scripts/InputXYNewest/InputXYNewest.gml
+++ b/scripts/InputXYNewest/InputXYNewest.gml
@@ -1,0 +1,106 @@
+// Feather disable all
+
+/// Returns along which axis, and what direction on that axis, the oldest held direction is
+/// pointing in. This is helpful for games where the player will typically instead to move along
+/// grid lines and off-axis movement is erroneous.
+/// 
+/// For example, if the player holds `left` and then subsequently presses and holds `up` then this
+/// function will return `{ x: -1, y: 0}`. If the player releases `left` and keeps `up` held then
+/// this function will return `{ x: 0, y: -1 }`. If the player relases `up` (so no verbs are held
+/// then the function will return `{ x: 0, y: 0 }`.
+/// 
+/// This function returns a struct that contains two member variables `x` and `y`. These values
+/// will always be either `0` `+1` or `-1` and only one axis cam be non-zero. This means this
+/// function will never return diagonal directions. This function is instead for use with keyboard
+/// or dpad input, or situations where a thumbstick should behave like a dpad.
+/// 
+/// Set the `preferX` parameter to `true` if the x-axis should be preferred if two verbs are
+/// pressed on exactly the same frame. Set to `false` if the y-axis should be preferred.
+/// 
+/// @param {Enum.INPUT_CLUSTER,Real} clusterIndex
+/// @param {Bool} preferX
+/// @param {Real} [playerIndex=0]
+
+function InputXYNewest(_clusterIndex, _preferX, _playerIndex = 0)
+{
+    static _playerArray = __InputSystemPlayerArray();
+    static _clusterDefinitionArray = __InputSystem().__clusterDefinitionArray;
+    
+    static _result = {};
+    
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
+    _result.x = 0;
+    _result.y = 0;
+    
+    with(_playerArray[_playerIndex])
+    {
+        __INPUT_VALIDATE_CLUSTER_INDEX
+        
+        var _clusterDefinition = _clusterDefinitionArray[_clusterIndex];
+        if (is_struct(_clusterDefinition))
+        {
+            //Pull raw verb values so we can apply thresholds in 2D
+            var _verbStateArray = __verbStateArray;
+            var _stateU = _verbStateArray[_clusterDefinition.__verbUp   ];
+            var _stateR = _verbStateArray[_clusterDefinition.__verbRight];
+            var _stateD = _verbStateArray[_clusterDefinition.__verbDown ];
+            var _stateL = _verbStateArray[_clusterDefinition.__verbLeft ];
+            
+            var _pressU = _stateU.__held? _stateU.__pressFrame : -infinity;
+            var _pressR = _stateR.__held? _stateR.__pressFrame : -infinity;
+            var _pressD = _stateD.__held? _stateD.__pressFrame : -infinity;
+            var _pressL = _stateL.__held? _stateL.__pressFrame : -infinity;
+            
+            var _pressMax = max(_pressU, _pressR, _pressD, _pressL);
+            if (not is_infinity(_pressMax))
+            {
+                var _recentU = (_pressMax == _pressU);
+                var _recentR = (_pressMax == _pressR);
+                var _recentD = (_pressMax == _pressD);
+                var _recentL = (_pressMax == _pressL);
+                
+                if (_preferX)
+                {
+                    if (_recentL)
+                    {
+                        if (not _recentR) _result.x = -1;
+                    }
+                    else if (_recentR)
+                    {
+                        if (not _recentL) _result.x = 1;
+                    }
+                    else if (_recentU)
+                    {
+                        if (not _recentD) _result.y = -1;
+                    }
+                    else if (_recentD)
+                    {
+                        if (not _recentU) _result.y = 1;
+                    }
+                }
+                else
+                {
+                    if (_recentU)
+                    {
+                        if (not _recentD) _result.y = -1;
+                    }
+                    else if (_recentD)
+                    {
+                        if (not _recentU) _result.y = 1;
+                    }
+                    else if (_recentL)
+                    {
+                        if (not _recentR) _result.x = -1;
+                    }
+                    else if (_recentR)
+                    {
+                        if (not _recentL) _result.x = 1;
+                    }
+                }
+            }
+        }
+    }
+    
+    return _result;
+}

--- a/scripts/InputXYNewest/InputXYNewest.yy
+++ b/scripts/InputXYNewest/InputXYNewest.yy
@@ -1,0 +1,13 @@
+{
+  "$GMScript":"v1",
+  "%Name":"InputXYNewest",
+  "isCompatibility":false,
+  "isDnD":false,
+  "name":"InputXYNewest",
+  "parent":{
+    "name":"Clusters",
+    "path":"folders/Input/Checkers/Clusters.yy",
+  },
+  "resourceType":"GMScript",
+  "resourceVersion":"2.0",
+}

--- a/scripts/InputXYOldest/InputXYOldest.gml
+++ b/scripts/InputXYOldest/InputXYOldest.gml
@@ -1,0 +1,102 @@
+// Feather disable all
+
+/// Returns along which axis, and what direction on that axis, the oldest held direction is
+/// pointing in. This is helpful for games where the player will typically instead to move along
+/// grid lines and off-axis movement is erroneous.
+/// 
+/// For example, if the player holds `left` and then subsequently presses and holds `up` then this
+/// function will return `{ x: -1, y: 0}`. If the player releases `left` and keeps `up` held then
+/// this function will return `{ x: 0, y: -1 }`. If the player relases `up` (so no verbs are held
+/// then the function will return `{ x: 0, y: 0 }`.
+/// 
+/// This function returns a struct that contains two member variables `x` and `y`. These values
+/// will always be either `0` `+1` or `-1` and only one axis cam be non-zero. As a result, this
+/// function is mostly instead for use with digital inputs such as a keyboard or dpad.
+/// 
+/// Set the `preferX` parameter to `true` if the x-axis should be preferred if two verbs are
+/// pressed on exactly the same frame. Set to `false` if the y-axis should be preferred.
+/// 
+/// @param {Enum.INPUT_CLUSTER,Real} clusterIndex
+/// @param preferX
+/// @param {Real} [playerIndex=0]
+
+function InputXYOldest(_clusterIndex, _preferX, _playerIndex = 0)
+{
+    static _playerArray = __InputSystemPlayerArray();
+    static _clusterDefinitionArray = __InputSystem().__clusterDefinitionArray;
+    
+    static _result = {};
+    
+    __INPUT_VALIDATE_PLAYER_INDEX
+    
+    _result.x = 0;
+    _result.y = 0;
+    
+    with(_playerArray[_playerIndex])
+    {
+        __INPUT_VALIDATE_CLUSTER_INDEX
+        
+        var _clusterDefinition = _clusterDefinitionArray[_clusterIndex];
+        if (is_struct(_clusterDefinition))
+        {
+            //Pull raw verb values so we can apply thresholds in 2D
+            var _verbStateArray = __verbStateArray;
+            var _stateU = _verbStateArray[_clusterDefinition.__verbUp   ];
+            var _stateR = _verbStateArray[_clusterDefinition.__verbRight];
+            var _stateD = _verbStateArray[_clusterDefinition.__verbDown ];
+            var _stateL = _verbStateArray[_clusterDefinition.__verbLeft ];
+            
+            var _pressU = _stateU.__held? _stateU.__pressFrame : infinity;
+            var _pressR = _stateR.__held? _stateR.__pressFrame : infinity;
+            var _pressD = _stateD.__held? _stateD.__pressFrame : infinity;
+            var _pressL = _stateL.__held? _stateL.__pressFrame : infinity;
+            
+            var _pressMin = min(_pressU, _pressR, _pressD, _pressL);
+            var _recentU = (_pressMin == _pressU);
+            var _recentR = (_pressMin == _pressR);
+            var _recentD = (_pressMin == _pressD);
+            var _recentL = (_pressMin == _pressL);
+            
+            if (_preferX)
+            {
+                if (_recentL)
+                {
+                    if (not _recentR) _result.x = -1;
+                }
+                else if (_recentR)
+                {
+                    if (not _recentL) _result.x = 1;
+                }
+                else if (_recentU)
+                {
+                    if (not _recentD) _result.y = -1;
+                }
+                else if (_recentD)
+                {
+                    if (not _recentU) _result.y = 1;
+                }
+            }
+            else
+            {
+                if (_recentU)
+                {
+                    if (not _recentD) _result.y = -1;
+                }
+                else if (_recentD)
+                {
+                    if (not _recentU) _result.y = 1;
+                }
+                else if (_recentL)
+                {
+                    if (not _recentR) _result.x = -1;
+                }
+                else if (_recentR)
+                {
+                    if (not _recentL) _result.x = 1;
+                }
+            }
+        }
+    }
+    
+    return _result;
+}

--- a/scripts/InputXYOldest/InputXYOldest.gml
+++ b/scripts/InputXYOldest/InputXYOldest.gml
@@ -10,14 +10,15 @@
 /// then the function will return `{ x: 0, y: 0 }`.
 /// 
 /// This function returns a struct that contains two member variables `x` and `y`. These values
-/// will always be either `0` `+1` or `-1` and only one axis cam be non-zero. As a result, this
-/// function is mostly instead for use with digital inputs such as a keyboard or dpad.
+/// will always be either `0` `+1` or `-1` and only one axis cam be non-zero. This means this
+/// function will never return diagonal directions. This function is instead for use with keyboard
+/// or dpad input, or situations where a thumbstick should behave like a dpad.
 /// 
 /// Set the `preferX` parameter to `true` if the x-axis should be preferred if two verbs are
 /// pressed on exactly the same frame. Set to `false` if the y-axis should be preferred.
 /// 
 /// @param {Enum.INPUT_CLUSTER,Real} clusterIndex
-/// @param preferX
+/// @param {Bool} preferX
 /// @param {Real} [playerIndex=0]
 
 function InputXYOldest(_clusterIndex, _preferX, _playerIndex = 0)

--- a/scripts/InputXYOldest/InputXYOldest.gml
+++ b/scripts/InputXYOldest/InputXYOldest.gml
@@ -1,7 +1,7 @@
 // Feather disable all
 
 /// Returns along which axis, and what direction on that axis, the oldest held direction is
-/// pointing in. This is helpful for games where the player will typically instead to move along
+/// pointing in. This is helpful for games where the player will typically intend to move along
 /// grid lines and off-axis movement is erroneous.
 /// 
 /// For example, if the player holds `left` and then subsequently presses and holds `up` then this

--- a/scripts/InputXYOldest/InputXYOldest.gml
+++ b/scripts/InputXYOldest/InputXYOldest.gml
@@ -53,47 +53,50 @@ function InputXYOldest(_clusterIndex, _preferX, _playerIndex = 0)
             var _pressL = _stateL.__held? _stateL.__pressFrame : infinity;
             
             var _pressMin = min(_pressU, _pressR, _pressD, _pressL);
-            var _recentU = (_pressMin == _pressU);
-            var _recentR = (_pressMin == _pressR);
-            var _recentD = (_pressMin == _pressD);
-            var _recentL = (_pressMin == _pressL);
-            
-            if (_preferX)
+            if (not is_infinity(_pressMin))
             {
-                if (_recentL)
+                var _recentU = (_pressMin == _pressU);
+                var _recentR = (_pressMin == _pressR);
+                var _recentD = (_pressMin == _pressD);
+                var _recentL = (_pressMin == _pressL);
+                
+                if (_preferX)
                 {
-                    if (not _recentR) _result.x = -1;
+                    if (_recentL)
+                    {
+                        if (not _recentR) _result.x = -1;
+                    }
+                    else if (_recentR)
+                    {
+                        if (not _recentL) _result.x = 1;
+                    }
+                    else if (_recentU)
+                    {
+                        if (not _recentD) _result.y = -1;
+                    }
+                    else if (_recentD)
+                    {
+                        if (not _recentU) _result.y = 1;
+                    }
                 }
-                else if (_recentR)
+                else
                 {
-                    if (not _recentL) _result.x = 1;
-                }
-                else if (_recentU)
-                {
-                    if (not _recentD) _result.y = -1;
-                }
-                else if (_recentD)
-                {
-                    if (not _recentU) _result.y = 1;
-                }
-            }
-            else
-            {
-                if (_recentU)
-                {
-                    if (not _recentD) _result.y = -1;
-                }
-                else if (_recentD)
-                {
-                    if (not _recentU) _result.y = 1;
-                }
-                else if (_recentL)
-                {
-                    if (not _recentR) _result.x = -1;
-                }
-                else if (_recentR)
-                {
-                    if (not _recentL) _result.x = 1;
+                    if (_recentU)
+                    {
+                        if (not _recentD) _result.y = -1;
+                    }
+                    else if (_recentD)
+                    {
+                        if (not _recentU) _result.y = 1;
+                    }
+                    else if (_recentL)
+                    {
+                        if (not _recentR) _result.x = -1;
+                    }
+                    else if (_recentR)
+                    {
+                        if (not _recentL) _result.x = 1;
+                    }
                 }
             }
         }

--- a/scripts/InputXYOldest/InputXYOldest.yy
+++ b/scripts/InputXYOldest/InputXYOldest.yy
@@ -1,0 +1,13 @@
+{
+  "$GMScript":"v1",
+  "%Name":"InputXYOldest",
+  "isCompatibility":false,
+  "isDnD":false,
+  "name":"InputXYOldest",
+  "parent":{
+    "name":"Clusters",
+    "path":"folders/Input/Checkers/Clusters.yy",
+  },
+  "resourceType":"GMScript",
+  "resourceVersion":"2.0",
+}


### PR DESCRIPTION
This PR adds three functions that handle input with an awareness of when verbs were pressed. These have niche uses, such as for grid-based movement or for a future combo plug-in (dibs on not writing that one (again)).

- `InputOldest()` is sorta the inverse of `InputMostRecent()`. It returns the verb that has been held for the longest time out of the array of verbs provided (or `-1` for all verbs).
- `InputXYOldest()` uses a cluster to return the oldest cardinal direction that the player is moving in. This is intended for filtering out off-axis movement. Some sokoban-style games work like this.
- `InputXYNewest()` is similar to above but returns the newest cardinal direction instead.