### PR TITLE
Adds an extra verb example for PS5 support

### DIFF
--- a/scripts/__InputConfigVerbs/__InputConfigVerbs.gml
+++ b/scripts/__InputConfigVerbs/__InputConfigVerbs.gml
@@ -12,6 +12,7 @@ function __InputConfigVerbs()
         ACTION,
         SPECIAL,
         PAUSE,
+        MAP,
     }
     
     enum INPUT_CLUSTER
@@ -21,30 +22,35 @@ function __InputConfigVerbs()
         NAVIGATION,
     }
     
-    if (not INPUT_ON_SWITCH)
+    InputDefineVerb(INPUT_VERB.UP,      "up",         [vk_up,    "W"],    [-gp_axislv, gp_padu]);
+    InputDefineVerb(INPUT_VERB.DOWN,    "down",       [vk_down,  "S"],    [ gp_axislv, gp_padd]);
+    InputDefineVerb(INPUT_VERB.LEFT,    "left",       [vk_left,  "A"],    [-gp_axislh, gp_padl]);
+    InputDefineVerb(INPUT_VERB.RIGHT,   "right",      [vk_right, "D"],    [ gp_axislh, gp_padr]);
+    InputDefineVerb(INPUT_VERB.ACTION,  "action",      vk_enter,            gp_face3);
+    InputDefineVerb(INPUT_VERB.SPECIAL, "special",     vk_shift,            gp_face4);
+    
+    if (INPUT_ON_SWITCH)
     {
-        InputDefineVerb(INPUT_VERB.UP,      "up",         [vk_up,    "W"],    [-gp_axislv, gp_padu]);
-        InputDefineVerb(INPUT_VERB.DOWN,    "down",       [vk_down,  "S"],    [ gp_axislv, gp_padd]);
-        InputDefineVerb(INPUT_VERB.LEFT,    "left",       [vk_left,  "A"],    [-gp_axislh, gp_padl]);
-        InputDefineVerb(INPUT_VERB.RIGHT,   "right",      [vk_right, "D"],    [ gp_axislh, gp_padr]);
-        InputDefineVerb(INPUT_VERB.ACCEPT,  "accept",      vk_space,            gp_face1);
-        InputDefineVerb(INPUT_VERB.CANCEL,  "cancel",      vk_backspace,        gp_face2);
-        InputDefineVerb(INPUT_VERB.ACTION,  "action",      vk_enter,            gp_face3);
-        InputDefineVerb(INPUT_VERB.SPECIAL, "special",     vk_shift,            gp_face4);
-        InputDefineVerb(INPUT_VERB.PAUSE,   "pause",       vk_escape,           gp_start);
+        //Flip A/B over on Switch
+        InputDefineVerb(INPUT_VERB.ACCEPT, "accept", undefined, gp_face2); // !!
+        InputDefineVerb(INPUT_VERB.CANCEL, "cancel", undefined, gp_face1); // !!
     }
-    else //Flip A/B over on Switch
+    else
     {
-        InputDefineVerb(INPUT_VERB.UP,      "up",      undefined, [-gp_axislv, gp_padu]);
-        InputDefineVerb(INPUT_VERB.DOWN,    "down",    undefined, [ gp_axislv, gp_padd]);
-        InputDefineVerb(INPUT_VERB.LEFT,    "left",    undefined, [-gp_axislh, gp_padl]);
-        InputDefineVerb(INPUT_VERB.RIGHT,   "right",   undefined, [ gp_axislh, gp_padr]);
-        InputDefineVerb(INPUT_VERB.ACCEPT,  "accept",  undefined,   gp_face2); // !!
-        InputDefineVerb(INPUT_VERB.CANCEL,  "cancel",  undefined,   gp_face1); // !!
-        InputDefineVerb(INPUT_VERB.ACTION,  "action",  undefined,   gp_face3);
-        InputDefineVerb(INPUT_VERB.SPECIAL, "special", undefined,   gp_face4);
-        InputDefineVerb(INPUT_VERB.PAUSE,   "pause",   undefined,   gp_start);
+        InputDefineVerb(INPUT_VERB.ACCEPT, "accept", vk_space,     gp_face1);
+        InputDefineVerb(INPUT_VERB.CANCEL, "cancel", vk_backspace, gp_face2);
     }
+    
+    if (INPUT_ON_PS5)
+    {
+        //`gp_select` is inaccessible on PS5
+        InputDefineVerb(INPUT_VERB.MAP, "map", vk_backspace, gp_touchpadbutton);
+    }
+    else
+    {
+        InputDefineVerb(INPUT_VERB.MAP, "map", vk_backspace, gp_select);
+    }
+    
     
     //Define a cluster of verbs for moving around
     InputDefineCluster(INPUT_CLUSTER.NAVIGATION, INPUT_VERB.UP, INPUT_VERB.RIGHT, INPUT_VERB.DOWN, INPUT_VERB.LEFT);


### PR DESCRIPTION
`gp_select` is not available on PS5 because it is used to open the Create menu in the OS. Instead, the touchpad can be used in its place. This PR adds an example of `gp_touchpadbutton` use in the out-of-the-box verb bindings.