### PR TITLE
fix: correct docs threshold examples typos (max -> maxi)

### DIFF
--- a/docs/10.0/Functions-(Virtual-Buttons).md
+++ b/docs/10.0/Functions-(Virtual-Buttons).md
@@ -669,12 +669,12 @@ The struct returned from this method has the following member variables:
 var _struct = vbThumbstick.GetThreshold();
 
 if (vbThresholdMinDecr.Pressed()) _struct.min = max(0, _struct.min - 0.1);
-if (vbThresholdMinIncr.Pressed()) _struct.min = min(1, _struct.min + 0.1, _struct.max - 0.1);
+if (vbThresholdMinIncr.Pressed()) _struct.min = min(1, _struct.min + 0.1, _struct.maxi - 0.1);
 
-if (vbThresholdMaxDecr.Pressed()) _struct.min = max(0, _struct.min + 0.1, _struct.max - 0.1);
-if (vbThresholdMaxIncr.Pressed()) _struct.min = min(1, _struct.max + 0.1);
+if (vbThresholdMaxDecr.Pressed()) _struct.min = max(0, _struct.min + 0.1, _struct.maxi - 0.1);
+if (vbThresholdMaxIncr.Pressed()) _struct.min = min(1, _struct.maxi + 0.1);
 
-vbThumbstick.Threshold(_struct.min, _struct.max);
+vbThumbstick.Threshold(_struct.min, _struct.maxi);
 ```
 
 <!-- tabs:end -->

--- a/docs/10.1/Functions-(Virtual-Buttons).md
+++ b/docs/10.1/Functions-(Virtual-Buttons).md
@@ -669,12 +669,12 @@ The struct returned from this method has the following member variables:
 var _struct = vbThumbstick.GetThreshold();
 
 if (vbThresholdMinDecr.Pressed()) _struct.min = max(0, _struct.min - 0.1);
-if (vbThresholdMinIncr.Pressed()) _struct.min = min(1, _struct.min + 0.1, _struct.max - 0.1);
+if (vbThresholdMinIncr.Pressed()) _struct.min = min(1, _struct.min + 0.1, _struct.maxi - 0.1);
 
-if (vbThresholdMaxDecr.Pressed()) _struct.min = max(0, _struct.min + 0.1, _struct.max - 0.1);
-if (vbThresholdMaxIncr.Pressed()) _struct.min = min(1, _struct.max + 0.1);
+if (vbThresholdMaxDecr.Pressed()) _struct.min = max(0, _struct.min + 0.1, _struct.maxi - 0.1);
+if (vbThresholdMaxIncr.Pressed()) _struct.min = min(1, _struct.maxi + 0.1);
 
-vbThumbstick.Threshold(_struct.min, _struct.max);
+vbThumbstick.Threshold(_struct.min, _struct.maxi);
 ```
 
 <!-- tabs:end -->

--- a/docs/10.2/Functions-(Virtual-Buttons).md
+++ b/docs/10.2/Functions-(Virtual-Buttons).md
@@ -669,12 +669,12 @@ The struct returned from this method has the following member variables:
 var _struct = vbThumbstick.GetThreshold();
 
 if (vbThresholdMinDecr.Pressed()) _struct.min = max(0, _struct.min - 0.1);
-if (vbThresholdMinIncr.Pressed()) _struct.min = min(1, _struct.min + 0.1, _struct.max - 0.1);
+if (vbThresholdMinIncr.Pressed()) _struct.min = min(1, _struct.min + 0.1, _struct.maxi - 0.1);
 
-if (vbThresholdMaxDecr.Pressed()) _struct.min = max(0, _struct.min + 0.1, _struct.max - 0.1);
-if (vbThresholdMaxIncr.Pressed()) _struct.min = min(1, _struct.max + 0.1);
+if (vbThresholdMaxDecr.Pressed()) _struct.min = max(0, _struct.min + 0.1, _struct.maxi - 0.1);
+if (vbThresholdMaxIncr.Pressed()) _struct.min = min(1, _struct.maxi + 0.1);
 
-vbThumbstick.Threshold(_struct.min, _struct.max);
+vbThumbstick.Threshold(_struct.min, _struct.maxi);
 ```
 
 <!-- tabs:end -->

--- a/docs/6.0/Functions-(Virtual-Button-Properties).md
+++ b/docs/6.0/Functions-(Virtual-Button-Properties).md
@@ -66,12 +66,12 @@ The struct returned from this method has the following member variables:
 var _struct = vb_thumbstick.get_threshold();
 
 if (vb_threshold_min_decr.pressed()) _struct.min = max(0, _struct.min - 0.1);
-if (vb_threshold_min_incr.pressed()) _struct.min = min(1, _struct.min + 0.1, _struct.max - 0.1);
+if (vb_threshold_min_incr.pressed()) _struct.min = min(1, _struct.min + 0.1, _struct.maxi - 0.1);
 
-if (vb_threshold_max_decr.pressed()) _struct.min = max(0, _struct.min + 0.1, _struct.max - 0.1);
-if (vb_threshold_max_incr.pressed()) _struct.min = min(1, _struct.max + 0.1);
+if (vb_threshold_max_decr.pressed()) _struct.min = max(0, _struct.min + 0.1, _struct.maxi - 0.1);
+if (vb_threshold_max_incr.pressed()) _struct.min = min(1, _struct.maxi + 0.1);
 
-vb_thumbstick.threshold(_struct.min, _struct.max);
+vb_thumbstick.threshold(_struct.min, _struct.maxi);
 ```
 
 <!-- tabs:end -->

--- a/docs/6.1/Functions-(Virtual-Button-Properties).md
+++ b/docs/6.1/Functions-(Virtual-Button-Properties).md
@@ -66,12 +66,12 @@ The struct returned from this method has the following member variables:
 var _struct = vb_thumbstick.get_threshold();
 
 if (vb_threshold_min_decr.pressed()) _struct.min = max(0, _struct.min - 0.1);
-if (vb_threshold_min_incr.pressed()) _struct.min = min(1, _struct.min + 0.1, _struct.max - 0.1);
+if (vb_threshold_min_incr.pressed()) _struct.min = min(1, _struct.min + 0.1, _struct.maxi - 0.1);
 
-if (vb_threshold_max_decr.pressed()) _struct.min = max(0, _struct.min + 0.1, _struct.max - 0.1);
-if (vb_threshold_max_incr.pressed()) _struct.min = min(1, _struct.max + 0.1);
+if (vb_threshold_max_decr.pressed()) _struct.min = max(0, _struct.min + 0.1, _struct.maxi - 0.1);
+if (vb_threshold_max_incr.pressed()) _struct.min = min(1, _struct.maxi + 0.1);
 
-vb_thumbstick.threshold(_struct.min, _struct.max);
+vb_thumbstick.threshold(_struct.min, _struct.maxi);
 ```
 
 <!-- tabs:end -->

--- a/docs/6.2/Functions-(Virtual-Button-Properties).md
+++ b/docs/6.2/Functions-(Virtual-Button-Properties).md
@@ -150,12 +150,12 @@ The struct returned from this method has the following member variables:
 var _struct = vb_thumbstick.get_threshold();
 
 if (vb_threshold_min_decr.pressed()) _struct.min = max(0, _struct.min - 0.1);
-if (vb_threshold_min_incr.pressed()) _struct.min = min(1, _struct.min + 0.1, _struct.max - 0.1);
+if (vb_threshold_min_incr.pressed()) _struct.min = min(1, _struct.min + 0.1, _struct.maxi - 0.1);
 
-if (vb_threshold_max_decr.pressed()) _struct.min = max(0, _struct.min + 0.1, _struct.max - 0.1);
-if (vb_threshold_max_incr.pressed()) _struct.min = min(1, _struct.max + 0.1);
+if (vb_threshold_max_decr.pressed()) _struct.min = max(0, _struct.min + 0.1, _struct.maxi - 0.1);
+if (vb_threshold_max_incr.pressed()) _struct.min = min(1, _struct.maxi + 0.1);
 
-vb_thumbstick.threshold(_struct.min, _struct.max);
+vb_thumbstick.threshold(_struct.min, _struct.maxi);
 ```
 
 <!-- tabs:end -->

--- a/docs/6.3/Functions-(Virtual-Button-Properties).md
+++ b/docs/6.3/Functions-(Virtual-Button-Properties).md
@@ -150,12 +150,12 @@ The struct returned from this method has the following member variables:
 var _struct = vb_thumbstick.get_threshold();
 
 if (vb_threshold_min_decr.pressed()) _struct.min = max(0, _struct.min - 0.1);
-if (vb_threshold_min_incr.pressed()) _struct.min = min(1, _struct.min + 0.1, _struct.max - 0.1);
+if (vb_threshold_min_incr.pressed()) _struct.min = min(1, _struct.min + 0.1, _struct.maxi - 0.1);
 
-if (vb_threshold_max_decr.pressed()) _struct.min = max(0, _struct.min + 0.1, _struct.max - 0.1);
-if (vb_threshold_max_incr.pressed()) _struct.min = min(1, _struct.max + 0.1);
+if (vb_threshold_max_decr.pressed()) _struct.min = max(0, _struct.min + 0.1, _struct.maxi - 0.1);
+if (vb_threshold_max_incr.pressed()) _struct.min = min(1, _struct.maxi + 0.1);
 
-vb_thumbstick.threshold(_struct.min, _struct.max);
+vb_thumbstick.threshold(_struct.min, _struct.maxi);
 ```
 
 <!-- tabs:end -->

--- a/docs/7.0/Functions-(Virtual-Button-Properties).md
+++ b/docs/7.0/Functions-(Virtual-Button-Properties).md
@@ -150,12 +150,12 @@ The struct returned from this method has the following member variables:
 var _struct = vb_thumbstick.get_threshold();
 
 if (vb_threshold_min_decr.pressed()) _struct.min = max(0, _struct.min - 0.1);
-if (vb_threshold_min_incr.pressed()) _struct.min = min(1, _struct.min + 0.1, _struct.max - 0.1);
+if (vb_threshold_min_incr.pressed()) _struct.min = min(1, _struct.min + 0.1, _struct.maxi - 0.1);
 
-if (vb_threshold_max_decr.pressed()) _struct.min = max(0, _struct.min + 0.1, _struct.max - 0.1);
-if (vb_threshold_max_incr.pressed()) _struct.min = min(1, _struct.max + 0.1);
+if (vb_threshold_max_decr.pressed()) _struct.min = max(0, _struct.min + 0.1, _struct.maxi - 0.1);
+if (vb_threshold_max_incr.pressed()) _struct.min = min(1, _struct.maxi + 0.1);
 
-vb_thumbstick.threshold(_struct.min, _struct.max);
+vb_thumbstick.threshold(_struct.min, _struct.maxi);
 ```
 
 <!-- tabs:end -->

--- a/docs/8.0/Functions-(Virtual-Button-Properties).md
+++ b/docs/8.0/Functions-(Virtual-Button-Properties).md
@@ -150,12 +150,12 @@ The struct returned from this method has the following member variables:
 var _struct = vb_thumbstick.get_threshold();
 
 if (vb_threshold_min_decr.pressed()) _struct.min = max(0, _struct.min - 0.1);
-if (vb_threshold_min_incr.pressed()) _struct.min = min(1, _struct.min + 0.1, _struct.max - 0.1);
+if (vb_threshold_min_incr.pressed()) _struct.min = min(1, _struct.min + 0.1, _struct.maxi - 0.1);
 
-if (vb_threshold_max_decr.pressed()) _struct.min = max(0, _struct.min + 0.1, _struct.max - 0.1);
-if (vb_threshold_max_incr.pressed()) _struct.min = min(1, _struct.max + 0.1);
+if (vb_threshold_max_decr.pressed()) _struct.min = max(0, _struct.min + 0.1, _struct.maxi - 0.1);
+if (vb_threshold_max_incr.pressed()) _struct.min = min(1, _struct.maxi + 0.1);
 
-vb_thumbstick.threshold(_struct.min, _struct.max);
+vb_thumbstick.threshold(_struct.min, _struct.maxi);
 ```
 
 <!-- tabs:end -->

--- a/docs/8.1/Functions-(Virtual-Button-Properties).md
+++ b/docs/8.1/Functions-(Virtual-Button-Properties).md
@@ -150,12 +150,12 @@ The struct returned from this method has the following member variables:
 var _struct = vb_thumbstick.get_threshold();
 
 if (vb_threshold_min_decr.pressed()) _struct.min = max(0, _struct.min - 0.1);
-if (vb_threshold_min_incr.pressed()) _struct.min = min(1, _struct.min + 0.1, _struct.max - 0.1);
+if (vb_threshold_min_incr.pressed()) _struct.min = min(1, _struct.min + 0.1, _struct.maxi - 0.1);
 
-if (vb_threshold_max_decr.pressed()) _struct.min = max(0, _struct.min + 0.1, _struct.max - 0.1);
-if (vb_threshold_max_incr.pressed()) _struct.min = min(1, _struct.max + 0.1);
+if (vb_threshold_max_decr.pressed()) _struct.min = max(0, _struct.min + 0.1, _struct.maxi - 0.1);
+if (vb_threshold_max_incr.pressed()) _struct.min = min(1, _struct.maxi + 0.1);
 
-vb_thumbstick.threshold(_struct.min, _struct.max);
+vb_thumbstick.threshold(_struct.min, _struct.maxi);
 ```
 
 <!-- tabs:end -->


### PR DESCRIPTION
Corrects small typo in examples for `GetThreshold` method (max -> maxi).

I didn't see any info on the repo about how to contribute to the docs, so I assume this is the way to do it. Happy to do something else if there is a different system and I just missed it.