### PR TITLE
Fixed invalid links to rebinding page

### DIFF
--- a/docs/10.0/Frequently-Asked.md
+++ b/docs/10.0/Frequently-Asked.md
@@ -49,7 +49,7 @@ Please see [Importing The Library](Importing-The-Library) for detailed instructi
 
 ## How do I save and load player bindings? {docsify-ignore}
 
-Using binding [export and import](Functions-(Rebindings)) functions. You should save bindings to a file for loading later.
+Using binding [export and import](Functions-(Rebinding)) functions. You should save bindings to a file for loading later.
 
 &nbsp;
 

--- a/docs/10.1/Frequently-Asked.md
+++ b/docs/10.1/Frequently-Asked.md
@@ -49,7 +49,7 @@ Please see [Importing The Library](Importing-The-Library) for detailed instructi
 
 ## How do I save and load player bindings? {docsify-ignore}
 
-Using binding [export and import](Functions-(Rebindings)) functions. You should save bindings to a file for loading later.
+Using binding [export and import](Functions-(Rebinding)) functions. You should save bindings to a file for loading later.
 
 &nbsp;
 

--- a/docs/10.1/Functions-(Plug-ins).md
+++ b/docs/10.1/Functions-(Plug-ins).md
@@ -590,30 +590,6 @@ A list of valid gamepad types can be found [here](Functions-(Player)?id=getgamep
 
 &nbsp;
 
-## …PlugInError
-
-`InputPlugInError(value1, [value2], [...])`
-
-<!-- tabs:start -->
-
-#### **Description**
-
-**Returns:** N/A (`undefined`)
-
-|Name        |Datatype       |Purpose                                |
-|------------|---------------|---------------------------------------|
-|`value[1-n]`|any            |Value to stringify                     |
-
-#### **Example**
-
-```gml
-{
-    
-}
-```
-<!-- tabs:end -->
-&nbsp;
-
 ## …PlugInWarning
 
 `InputPlugInWarning(value1, [value2], [...])`

--- a/docs/10.2/Frequently-Asked.md
+++ b/docs/10.2/Frequently-Asked.md
@@ -49,7 +49,7 @@ Please see [Importing The Library](Importing-The-Library) for detailed instructi
 
 ## How do I save and load player bindings? {docsify-ignore}
 
-Using binding [export and import](Functions-(Rebindings)) functions. You should save bindings to a file for loading later.
+Using binding [export and import](Functions-(Rebinding)) functions. You should save bindings to a file for loading later.
 
 &nbsp;
 

--- a/docs/10.2/Functions-(Plug-ins).md
+++ b/docs/10.2/Functions-(Plug-ins).md
@@ -590,30 +590,6 @@ A list of valid gamepad types can be found [here](Functions-(Player)?id=getgamep
 
 &nbsp;
 
-## …PlugInError
-
-`InputPlugInError(value1, [value2], [...])`
-
-<!-- tabs:start -->
-
-#### **Description**
-
-**Returns:** N/A (`undefined`)
-
-|Name        |Datatype       |Purpose                                |
-|------------|---------------|---------------------------------------|
-|`value[1-n]`|any            |Value to stringify                     |
-
-#### **Example**
-
-```gml
-{
-    
-}
-```
-<!-- tabs:end -->
-&nbsp;
-
 ## …PlugInWarning
 
 `InputPlugInWarning(value1, [value2], [...])`


### PR DESCRIPTION
The current FAQ pages links to Functions-(Rebindings), when the page itself is called Functions-(Rebinding).