### PR TITLE
Fixed invalid links to rebinding page

### DIFF
--- a/docs/10.0/Frequently-Asked.md
+++ b/docs/10.0/Frequently-Asked.md
@@ -49,7 +49,7 @@ Please see [Importing The Library](Importing-The-Library) for detailed instructi
 
 ## How do I save and load player bindings? {docsify-ignore}
 
-Using binding [export and import](Functions-(Rebindings)) functions. You should save bindings to a file for loading later.
+Using binding [export and import](Functions-(Rebinding)) functions. You should save bindings to a file for loading later.
 
 &nbsp;
 

--- a/docs/10.1/Frequently-Asked.md
+++ b/docs/10.1/Frequently-Asked.md
@@ -49,7 +49,7 @@ Please see [Importing The Library](Importing-The-Library) for detailed instructi
 
 ## How do I save and load player bindings? {docsify-ignore}
 
-Using binding [export and import](Functions-(Rebindings)) functions. You should save bindings to a file for loading later.
+Using binding [export and import](Functions-(Rebinding)) functions. You should save bindings to a file for loading later.
 
 &nbsp;
 

--- a/docs/10.2/Frequently-Asked.md
+++ b/docs/10.2/Frequently-Asked.md
@@ -49,7 +49,7 @@ Please see [Importing The Library](Importing-The-Library) for detailed instructi
 
 ## How do I save and load player bindings? {docsify-ignore}
 
-Using binding [export and import](Functions-(Rebindings)) functions. You should save bindings to a file for loading later.
+Using binding [export and import](Functions-(Rebinding)) functions. You should save bindings to a file for loading later.
 
 &nbsp;
 


### PR DESCRIPTION
Round 2!

The current FAQ pages links to Functions-(Rebindings), when the page itself is called Functions-(Rebinding).